### PR TITLE
Fix 'Failed to malloc ckbuf in hash_search2' with very large files.

### DIFF
--- a/rzip.c
+++ b/rzip.c
@@ -745,7 +745,7 @@ static inline bool hash_search(rzip_control *control, struct rzip_state *st,
 		cksum_chunks = control->checksum.len / control->maxram;
 		cksum_remains = control->checksum.len % control->maxram;
 
-		control->checksum.buf = malloc(control->checksum.len);
+		control->checksum.buf = malloc(control->maxram);
 		if (unlikely(!control->checksum.buf))
 			fatal_return(("Failed to malloc ckbuf in hash_search2\n"), false);
 


### PR DESCRIPTION
lrzip was trying to malloc() enough memory to fit the entire length of file it was going to hash, instead of just the size of one chunk. This caused problems when combined with extremely large files.
