### PR TITLE
fix order of lrzip.conf search

### DIFF
--- a/util.c
+++ b/util.c
@@ -188,11 +188,6 @@ bool read_config(rzip_control *control)
 	if (fp)
 		fprintf(control->msgout, "Using configuration file ./lrzip.conf\n");
 	if (fp == NULL) {
-		fp = fopen("/etc/lrzip/lrzip.conf", "r");
-		if (fp)
-			fprintf(control->msgout, "Using configuration file /etc/lrzip/lrzip.conf\n");
-	}
-	if (fp == NULL) {
 		HOME=getenv("HOME");
 		if (HOME) {
 			snprintf(homeconf, sizeof(homeconf), "%s/.lrzip/lrzip.conf", HOME);
@@ -200,6 +195,11 @@ bool read_config(rzip_control *control)
 			if (fp)
 				fprintf(control->msgout, "Using configuration file %s\n", homeconf);
 		}
+	}
+	if (fp == NULL) {
+		fp = fopen("/etc/lrzip/lrzip.conf", "r");
+		if (fp)
+			fprintf(control->msgout, "Using configuration file /etc/lrzip/lrzip.conf\n");
 	}
 	if (fp == NULL)
 		return true;


### PR DESCRIPTION
The design of read_config is to check for the existence of lrzip.conf in 1: current dir, 2: $HOME/.lrzip, 3: /etc/lrzip. The actual coding put /etc before $HOME. This code fixes the order as designed.