### PR TITLE
Reformatted man page

### DIFF
--- a/main.c
+++ b/main.c
@@ -103,6 +103,7 @@ static void usage(bool compat)
 	print_output("	-O, --outdir directory	specify the output directory when -o is not used\n");
 	print_output("	-S, --suffix suffix	specify compressed suffix (default '.lrz')\n");
 	print_output("Options affecting compression:\n");
+	print_output("	--lzma			lzma compression (default)\n");
 	print_output("	-b, --bzip2		bzip2 compression\n");
 	print_output("	-g, --gzip		gzip compression using zlib\n");
 	print_output("	-l, --lzo		lzo compression (ultra fast)\n");
@@ -224,24 +225,25 @@ static struct option long_options[] = {
 	{"keep-broken",	no_argument,	0,	'k'},
 	{"keep-broken",	no_argument,	0,	'K'},
 	{"lzo",		no_argument,	0,	'l'},
-	{"level",	required_argument,	0,	'L'},
-	{"maxram",	required_argument,	0,	'm'}, /* 15 */
+	{"lzma",       	no_argument,	0,	'/'},
+	{"level",	required_argument,	0,	'L'}, /* 15 */
+	{"maxram",	required_argument,	0,	'm'},
 	{"no-compress",	no_argument,	0,	'n'},
 	{"nice-level",	required_argument,	0,	'N'},
 	{"outfile",	required_argument,	0,	'o'},
-	{"outdir",	required_argument,	0,	'O'},
-	{"threads",	required_argument,	0,	'p'}, /* 20 */
+	{"outdir",	required_argument,	0,	'O'}, /* 20 */
+	{"threads",	required_argument,	0,	'p'},
 	{"progress",	no_argument,	0,	'P'},
 	{"quiet",	no_argument,	0,	'q'},
 	{"recursive",	no_argument,	0,	'r'},
 	{"suffix",	required_argument,	0,	'S'},
-	{"test",	no_argument,	0,	't'},
-	{"threshold",	required_argument,	0,	'T'}, /* 25 */
+	{"test",	no_argument,	0,	't'},  /* 25 */
+	{"threshold",	required_argument,	0,	'T'},
 	{"unlimited",	no_argument,	0,	'U'},
 	{"verbose",	no_argument,	0,	'v'},
 	{"version",	no_argument,	0,	'V'},
-	{"window",	required_argument,	0,	'w'},
-	{"zpaq",	no_argument,	0,	'z'}, /* 30 */
+	{"window",	required_argument,	0,	'w'},  /* 30 */
+	{"zpaq",	no_argument,	0,	'z'},
 	{"fast",	no_argument,	0,	'1'},
 	{"best",	no_argument,	0,	'9'},
 	{0,	0,	0,	0},

--- a/man/lrz.1.pod
+++ b/man/lrz.1.pod
@@ -1,3 +1,5 @@
+#!/usr/bin/perl -w
+
 #   Copyright
 #
 #      Copyright (C) 2016 Con Kolivas
@@ -38,63 +40,278 @@
 
 =pod
 
+=encoding utf8
+
 =head1 NAME
 
 lrz - gzip compatible command line variant of lrzip
 
+
 =head1 SYNOPSIS
 
-  lrz [OPTIONS] <file>
+B<lrz> [options] I<file>
+
 
 =head1 DESCRIPTION
 
-lrz is identical to the lrzip application however its command line options and
-behaviour are made to be as compatible with gzip as possible.
+B<lrz> is identical to the B<lrzip> application, however, its command
+line options and behaviour are made to be as compatible with B<gzip>
+as possible.
 
 =head1 OPTIONS
 
-lrz differs from lrzip by accepting the following commands:
+=head2 General options
 
-General options:
-        -c, --stdout            output to STDOUT
-        -C, --check             check integrity of file written on decompression
-        -d, --decompress        decompress
-        -e, --encrypt           password protected sha512/aes128 encryption on compression
-        -h, -?, --help          show help
-        -H, --hash              display md5 hash integrity information
-        -i, --info              show compressed file information
-        -L, --license           display software version and license
-        -P, --progress          show compression progress
-        -r, --recursive         operate recursively on directories
-        -t, --test              test compressed file integrity
-        -v[vv], --verbose       Increase verbosity
-        -V, --version           show version
-Options affecting output:
-        -f, --force             force overwrite of any existing files
-        -k, --keep              don't delete source files on de/compression
-        -K, --keep-broken       keep broken or damaged output files
-        -o, --outfile filename  specify the output file name and/or path
-        -O, --outdir directory  specify the output directory when -o is not used
-        -S, --suffix suffix     specify compressed suffix (default '.lrz')
-Options affecting compression:
-        -b, --bzip2             bzip2 compression
-        -g, --gzip              gzip compression using zlib
-        -l, --lzo               lzo compression (ultra fast)
-        -n, --no-compress       no backend compression - prepare for other compressor
-        -z, --zpaq              zpaq compression (best, extreme compression, extremely slow)
-Low level options:
-        -1 .. -9                set lzma/bzip2/gzip compression level (1-9, default 7)
-        --fast                  alias for -1
-        --best                  alias for -9
-        -L, --level level       set lzma/bzip2/gzip compression level (1-9, default 7)
-        -N, --nice-level value  Set nice value to value (default 0)
-        -p, --threads value     Set processor count to override number of threads
-        -m, --maxram size       Set maximim available ram in hundreds of MB
-                                overrides detected ammount of available ram
-        -T, --threshold         Disable LZO compressibility testing
-        -U, --unlimited         Use unlimited window size beyond ramsize (potentially much slower)
-        -w, --window size       maximum compression window in hundreds of MB
-                                default chosen by heuristic dependent on ram and chosen compression
+=over 9
+
+=item B<--stdout>
+
+=item B<-c>
+
+Output to STDOUT.
+
+
+=item B<--check>
+
+=item B<-C>
+
+Check integrity of file written on decompression.
+
+
+=item B<--decompress>
+
+=item B<-d>
+
+Decompress.
+
+
+=item B<--encrypt>
+
+=item B<-e>
+
+Password protect sha512/aes128 encryption on compression.
+
+
+=item B<--help>
+
+=item B<-h>
+
+=item B<-?>
+
+Show help.
+
+
+=item B<--hash>
+
+=item B<-H>
+
+Display md5 hash integrity information.
+
+
+=item B<--info>
+
+=item B<-i>
+
+Show compressed file information.
+
+
+=item B<--license>
+
+=item B<-L>
+
+Display software version and license.
+
+
+=item B<--progress>
+
+=item B<-P>
+
+Show compression progress.
+
+
+=item B<--recursive>
+
+=item B<-r>
+
+Operate recursively on directories.
+
+
+=item B<--test>
+
+=item B<-t>
+
+Test compressed file integrity.
+
+
+=item B<--verbose>
+
+=item B<-v[vv]>
+
+Increase verbosity.
+
+
+=item B<--version>
+
+=item B<-V>
+
+Show version.
+
+
+=back
+
+
+=head2 Options affecting output
+
+=over 9
+
+=item B<--force>
+
+=item B<-f>
+
+Force overwrite of any existing files.
+
+
+=item B<--keep>
+
+=item B<-k>
+
+Don't delete source files on de/compression.
+
+
+=item B<--keep-broken>
+
+=item B<-K>
+
+Keep broken or damaged output files.
+
+
+=item B<--outfile>  I<name>
+
+=item B<-o> I<name>
+
+Specify the output file name and/or path.
+
+
+=item B<--outdir> I<dir>
+
+=item B<-O> I<dir>
+
+Specify the output directory when B<-o> is not used.
+
+
+=item B<--suffix> I<suffix>
+
+=item B<-S> I<suffix>
+
+Specify compressed suffix (default '.lrz').
+
+
+=back
+
+=head2 Options affecting compression
+
+=over 9
+
+=item B<--bzip2>
+
+=item B<-b>
+
+Bzip2 compression.
+
+=item B<--gzip>
+
+=item B<-g>
+
+Gzip compression using zlib.
+
+=item B<--lzo>
+
+=item B<-l>
+
+Lzo compression (ultra fast).
+
+=item B<--lzma>
+
+Lzma compression (default).
+
+=item B<--no-compress>
+
+=item B<-n>
+
+No backend compression - prepare for other compressor.
+
+=item B<--zpaq>
+
+=item B<-z>
+
+Zpaq compression (best, extreme compression, extremely slow).
+
+
+=back
+
+=head2 Low level options
+
+=over 9
+
+=item B<-1> .. B<-9>
+
+=item B<--level> I<level>
+
+=item B<-L> I<level>
+
+Set lzma/bzip2/gzip compression level (1-9, default 7).
+
+
+=item B<--fast>
+
+Alias for B<-1>.
+
+
+=item B<--best>
+
+Alias for B<-9>.
+
+
+=item B<--nice-level> I<value>
+
+=item B<-N> I<value>
+
+Set nice value to I<value> (default 0).
+
+
+=item B<--threads> I<value>
+
+=item B<-P> I<value>
+
+Set processor count to override number of threads.
+
+=item B<--maxram> I<size>
+
+=item B<-m> I<size>
+
+Set maximim available ram as I<size> * 100 MB.
+Overrides detected amount of available ram.
+
+=item B<--threshold>
+
+=item B<-T>
+
+Disable LZO compressibility testing.
+
+=item B<--unlimited>
+
+=item B<-U>
+
+Use unlimited window size beyond ramsize (potentially much slower).
+
+=item B<--window> I<size>
+
+=item B<-w> I<size>
+
+Set maximum compression window as I<size> * 100 MB.
+Default chosen by heuristic dependent on ram and chosen compression.
+
+=back
 
 See also lrzip(1)
 

--- a/regressiontest.good
+++ b/regressiontest.good
@@ -1,0 +1,49 @@
+Test basic use
+Test decompression in read-only dir
+   1000    1000    3893
+this should be silent
+man page for lrz should exist
+0
+compress stdin to stdout
+Respect $TMPDIR
+   1000    1000    3893
+Decompress in read only dir
+   1000    1000    3893
+Test -cd
+   1000    1000    3893
+Test -cfd should not remove testfile.lrz
+   1000    1000    3893
+testfile.lrz
+Test -1c
+   1002    1002    3975
+Test -r
+t10.lrz
+t1.lrz
+t2.lrz
+t3.lrz
+t4.lrz
+t5.lrz
+t6.lrz
+t7.lrz
+t8.lrz
+t9.lrz
+Test tar compatibility
+t/
+t/t8
+t/t7
+t/t3
+t/t5
+t/t2
+t/t6
+t/t10
+t/t4
+t/t9
+t/t1
+11
+test compress of 1 GB data with parallel --pipe --compress
+1073741824
+test compress of 1 GB with sort --compress-program
+1073741825
+test should not lrz -dc removes file
+OK
+testfile.lrz

--- a/regressiontest.sh
+++ b/regressiontest.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Regression test.
+#
+# Copyright (C) 2016
+# Ole Tange and Free Software Foundation, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# or write to the Free Software Foundation, Inc., 51 Franklin St,
+# Fifth Floor, Boston, MA 02110-1301 USA
+
+bash > regressiontest.out 2>&1  <<'_EOS'
+  rm -f testfile.lrz
+  seq 1000 > testfile
+  
+  echo 'Test basic use'
+    lrz testfile
+  
+  echo 'Test decompression in read-only dir'
+    mkdir -p ro
+    cp testfile.lrz ro
+    chmod 500 ro
+    cd ro
+    lrz -dc testfile.lrz | wc
+    cd ..
+  
+  echo 'this should be silent'
+    lrz -d testfile.lrz
+  
+  echo 'man page for lrz should exist'
+    man lrz >/dev/null
+    echo $?
+  
+  echo 'compress stdin to stdout'
+    cat testfile | lrz | cat > testfile.lrz
+  
+  echo 'Respect $TMPDIR'
+    mkdir -p t
+    chmod 111 t
+    cd t
+    TMPDIR=.. lrz -d < ../testfile.lrz | wc
+    cd ..
+    rm -rf t
+  
+  echo 'Decompress in read only dir'
+    mkdir -p t
+    chmod 111 t
+    cd t
+    lrz -d < ../testfile.lrz | wc
+    cd ..
+    rm -rf t
+  
+  echo 'Test -cd'
+    mkdir -p t
+    chmod 111 t
+    cd t
+    lrz -cd  ../testfile.lrz | wc
+    cd ..
+    rm -rf t
+
+  echo 'Test -cfd should not remove testfile.lrz'
+    mkdir -p t
+    chmod 111 t
+    cd t
+    lrz -cfd  ../testfile.lrz | wc
+    cd ..
+    rm -rf t
+    ls testfile.lrz
+
+  echo 'Test -1c'
+    lrz -1c testfile | wc
+
+  echo 'Test -r'
+    mkdir t
+    touch t/t{1..10}
+    lrz -r t
+    ls t
+    rm -r t
+
+  echo 'Test tar compatibility'
+    mkdir t
+    touch t/t{1..10}
+    tar --use-compress-program lrz -cvf testfile.tar.lrz t
+    tar --use-compress-program lrz -tvf testfile.tar.lrz | wc -l
+    rm -r t
+
+  echo 'test compress of 1 GB data with parallel --pipe --compress'
+    yes "`echo {1..100}`" |
+      head -c 1G |
+      parallel --pipe --block 100m --compress-program lrz cat |
+      wc -c
+
+  echo 'test compress of 1 GB with sort --compress-program'
+    yes "`echo {1..100}`" |
+      head -c 1G |
+      sort --compress-program lrz |
+      wc -c
+
+  echo 'test should not lrz -dc removes file'
+    rm testfile.lrz
+    echo OK > testfile
+    lrz testfile
+    lrz -dc testfile.lrz
+    ls testfile.lrz
+
+_EOS
+
+diff regressiontest.good regressiontest.out


### PR DESCRIPTION
The man page for lrz now looks reasonable even if the screen is not 140 char wide.

--lzma was added (doing nothing) to make it possible to mention --lzma is default in the man page.
