### PR TITLE
Fix Android Detection in lrzip_private.h

### DIFF
--- a/lrzip_private.h
+++ b/lrzip_private.h
@@ -144,7 +144,7 @@ extern int errno;
 #define unlikely(x)	__builtin_expect(!!(x), 0)
 #define __maybe_unused	__attribute__((unused))
 
-#if defined(__MINGW32__) || defined(__CYGWIN__) || defined(ANDROID) || defined(__APPLE__)
+#if defined(__MINGW32__) || defined(__CYGWIN__) || defined(__ANDROID__) || defined(__APPLE__)
 # define ffsll __builtin_ffsll
 #endif
 


### PR DESCRIPTION
lrzip_private.h was checking for "ANDROID" but
it should be __ANDROID__

lrzip now compiles just fine on android, it seems