### PR TITLE
lrztar -o fix

### DIFF
--- a/lrztar
+++ b/lrztar
@@ -137,11 +137,13 @@ Notice:
             s="${s%/}"
             p+=(-o "$i/${s##*/}.tar.${vopt[v_S]}");
         fi
-        ! ((v_f)) && [[ -e $i/${s##*/}.tar.${vopt[v_S]} ]] && {
-            printf "lrztar: %s exists, use -f to overwrite\n" \
-                   "$i/${s##*/}.tar.${vopt[v_S]}"
-            return 1
-        }
+        if ! ((v_o)); then 
+            ! ((v_f)) && [[ -e $i/${s##*/}.tar.${vopt[v_S]} ]] && {
+                printf "lrztar: %s exists, use -f to overwrite\n" \
+                    "$i/${s##*/}.tar.${vopt[v_S]}"
+                return 1
+            }
+        fi
         tar c "$s" | lrzip "${p[@]}"
         x=$?
     }


### PR DESCRIPTION
Fix handling of -o option which failed when used.

`LRZIP=NOCONFIG bash -x ./lrztar -n -o usr.5.tar.lrz usr`
\+ (( v_o ))
\+ (( v_f ))
\+ [[ -e usr.5.tar.lrz ]]
\+ (( v_o ))
\+ tar c usr
\+ lrzip -n -o usr.5.tar.lrz
 Compression Ratio: 1.297. Average Compression Speed: 44.643MB/s.
 Total time: 00:00:14.43
\+ x=0
\+ return 0