### PR TITLE
fix to allow compression in lrzip.conf to be overridden by command line

### DIFF
--- a/doc/lrzip.conf.example
+++ b/doc/lrzip.conf.example
@@ -13,7 +13,7 @@
 # Use -U setting, Unlimited ram. Yes or No
 # UNLIMITED = NO
 # Compression Method, rzip, gzip, bzip2, lzo, or lzma (default), or zpaq. (-n -g -b -l --lzma -z)
-# If specified here, command line options not usable.
+# May be overriden by command line compression choice.
 # COMPRESSIONMETHOD = lzma
 # Perform LZO Test. Default = YES (-T )
 # LZOTEST = NO


### PR DESCRIPTION
Corrects a bug that prevented compression choice in lrzip.conf from being used.
The issue stemmed from the fact that there is no flag set for the default LZMA compression, but individual flags are set for all the alternates, rzip, gzip, bzip2, lzo, zpaq