### PR TITLE
Small changes to control->threads and memory overhead for LZMA.

### DIFF
--- a/stream.c
+++ b/stream.c
@@ -325,7 +325,8 @@ retry:
 				lzma_level,
 				0, /* dict size. set default, choose by level */
 				-1, -1, -1, -1, /* lc, lp, pb, fb */
-				control->threads);
+				control->threads > 1 ? 2: 1);
+				/* LZMA spec has threads = 1 or 2 only. */
 	if (lzma_ret != SZ_OK) {
 		switch (lzma_ret) {
 			case SZ_ERROR_MEM:

--- a/util.c
+++ b/util.c
@@ -117,7 +117,9 @@ void setup_overhead(rzip_control *control)
 		i64 dictsize = (level <= 5 ? (1 << (level * 2 + 14)) :
 				(level == 6 ? (1 << 25) : (1 << 26)));
 
-		control->overhead = (dictsize * 23 / 2) + (4 * 1024 * 1024);
+		control->overhead = (dictsize * 23 / 2) + (6 * 1024 * 1024) + 16384;
+		/* LZMA spec shows memory requirements as 6MB, not 4MB and state size
+		 * where default is 16KB */
 	} else if (ZPAQ_COMPRESS)
 		control->overhead = 112 * 1024 * 1024;
 }


### PR DESCRIPTION
These changes correct two small issues. The LzmaCompress function should pass thread values of 1 or 2. The memory overhead computed in util.c for LZMA is corrected per spec. From LzmaLib.h

RAM requirements for LZMA:
```
for compression:   (dictSize * 11.5 + **6 MB**) + state_size
for decompression: dictSize + state_size
   state_size = (4 + (1.5 << (lc + lp))) KB
   by default (lc=3, lp=0), state_size = 16 KB.
```