### PR TITLE
Fixups to nice handling. Users can't normally lower niceness.

### DIFF
--- a/lrzip_core.h
+++ b/lrzip_core.h
@@ -47,4 +47,7 @@ extern void zpaq_compress(uchar *c_buf, i64 *c_len, uchar *s_buf, i64 s_len, int
 			  FILE *msgout, bool progress, long thread);
 extern void zpaq_decompress(uchar *s_buf, i64 *d_len, uchar *c_buf, i64 c_len,
 			    FILE *msgout, bool progress, long thread);
+
+static int current_priority;
+
 #endif

--- a/stream.c
+++ b/stream.c
@@ -1276,9 +1276,10 @@ static void *compthread(void *data)
 	cti = &cthread[i];
 	ctis = cti->sinfo;
 
-	if (unlikely(setpriority(PRIO_PROCESS, 0, control->nice_val) == -1))
-		print_err("Warning, unable to set nice value on thread\n");
-
+	if (unlikely(setpriority(PRIO_PROCESS, 0, control->nice_val) == -1)) {
+		print_err("Warning, unable to set thread nice value %d...Resetting to %d\n", control->nice_val, current_priority);
+		setpriority(PRIO_PROCESS, 0, (control->nice_val=current_priority));
+	}
 	cti->c_type = CTYPE_NONE;
 	cti->c_len = cti->s_len;
 
@@ -1512,8 +1513,10 @@ static void *ucompthread(void *data)
 	dealloc(data);
 	uci = &ucthread[i];
 
-	if (unlikely(setpriority(PRIO_PROCESS, 0, control->nice_val) == -1))
-		print_err("Warning, unable to set nice value on thread\n");
+	if (unlikely(setpriority(PRIO_PROCESS, 0, control->nice_val) == -1)) {
+		print_err("Warning, unable to set thread nice value %d...Resetting to %d\n", control->nice_val, current_priority);
+		setpriority(PRIO_PROCESS, 0, (control->nice_val=current_priority));
+	}
 
 retry:
 	if (uci->c_type != CTYPE_NONE) {


### PR DESCRIPTION
This PR updates priority setting.  A non-super user without CAP_SYS_NICE capability cannot lower priority setting. This fix updates the processing so that if an error is reported, the process and threaded processes will be reset to the original lrzip priority. It also corrects a small issue where 
`control->nice_val/2` would only be computed for positive nice values, not negative.