### PR TITLE
AC_CHECK_PROGS fix to recognize multiple assemblers.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,8 +69,8 @@ AC_ARG_ENABLE(
              )
 
 if test x"$ASM" = x"yes"; then
-	AC_CHECK_PROG( ASM_PROG, nasm, nasm, no ) # fix to set ASM_PROG to nasm, not yes.
-	if test x"$ASM_PROG" = x"no "; then
+	AC_CHECK_PROGS( ASM_PROG, nasm yasm, no, ) # fix to set ASM_PROG to nasm or yasm
+	if test x"$ASM_PROG" = x"no"; then
 		ASM=no
 	fi
 fi


### PR DESCRIPTION
There was a syntax error in configure.ac when checking for assemblers. It would incorrectly report there was an assembler when there wasn't. It also used the wrong macro AC_CHECK_PROG instead of AC_CHECK_PROG**S**.