### PR TITLE
Lrzip.h: add missing header for va_list on some platforms

### DIFF
--- a/Lrzip.h
+++ b/Lrzip.h
@@ -20,6 +20,7 @@
 #ifndef LIBLRZIP_H
 #define LIBLRZIP_H
 
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #ifdef _WIN32


### PR DESCRIPTION
Signed-off-by: Sam Lancia <sam@gpsm.co.uk>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/lrzip/0001-missing-stdarg.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>