### PR TITLE
lzma/C/Makefile.am: fix install with asm

### DIFF
--- a/lzma/C/Makefile.am
+++ b/lzma/C/Makefile.am
@@ -60,6 +60,7 @@ liblzma_la_LIBADD = $(ASM_7z).lo
 
 $(ASM_7z).lo: $(ASM_S)
 	$(ASM_PROG) $(ASM_OPT) -o $(ASM_7z).o $(ASM_S)
+	mkdir .libs
 	cp $(ASM_7z).o .libs/
 	@echo -e "$(7ZIPASMLOFILE)" > $(ASM_7z).lo 
 endif


### PR DESCRIPTION
Since commit 9f16f65705e2f1e11c41647405adcce6a12d286c, build with asm can fail on:

```
nasm -I../ASM/x86/ -Dx64 -f elf64 -o 7zCrcOpt_asm.o ../../lzma/ASM/x86/7zCrcOpt_asm.asm
  CC       LzmaEnc.lo
  CC       LzmaLib.lo
  CC       Alloc.lo
  CC       Threads.lo
cp 7zCrcOpt_asm.o .libs/
cp: cannot create regular file '.libs/': Not a directory
make[4]: *** [Makefile:678: 7zCrcOpt_asm.lo] Error 1
make[4]: *** Waiting for unfinished jobs....
```

So create .libs directory before copying 7zCrcOpt_asm.o

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>