### PR TITLE
lzma/C/Makefile.am: fix install with asm

### DIFF
--- a/lzma/C/Makefile.am
+++ b/lzma/C/Makefile.am
@@ -60,7 +60,7 @@ liblzma_la_LIBADD = $(ASM_7z).lo
 
 $(ASM_7z).lo: $(ASM_S)
 	$(ASM_PROG) $(ASM_OPT) -o $(ASM_7z).o $(ASM_S)
-	mkdir .libs
+	mkdir -p .libs
 	cp $(ASM_7z).o .libs/
 	@echo -e "$(7ZIPASMLOFILE)" > $(ASM_7z).lo 
 endif


### PR DESCRIPTION
Commit 3734448abc18cc8b92bef415dfac7adbacfdc148 fixed the build failure
due to .libs being missing but it raises a build failure when .libs is
already there:

```
nasm -I../ASM/x86/ -Dx64 -f elf64 -o 7zCrcOpt_asm.o ../../lzma/ASM/x86/7zCrcOpt_asm.asm
mkdir .libs
mkdir: cannot create directory '.libs': File exists
```

Fix this error by adding -p argument to mkdir

Fixes:
- http://autobuild.buildroot.org/results/1ca6db24ef26c57d4c129de7e98383e7e58b366b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>