### PR TITLE
BUGFIX: lrzip -d, -t should allow a file with or without an lrz extension and add if necessary

### DIFF
--- a/lrzip.c
+++ b/lrzip.c
@@ -693,26 +693,27 @@ bool decompress_file(rzip_control *control)
 
 	if (!STDIN && !IS_FROM_FILE) {
 		struct stat fdin_stat;
-
-		stat(control->infile, &fdin_stat);
-		if (!S_ISREG(fdin_stat.st_mode) && (tmp = strrchr(control->infile, '.')) &&
-		    strcmp(tmp,control->suffix)) {
-			/* make sure infile has an extension. If not, add it
-			  * because manipulations may be made to input filename, set local ptr
-			*/
+		/* make sure infile has an extension. If not, add it
+		 * because manipulations may be made to input filename, set local ptr
+		*/
+		tmp = strrchr(control->infile, '.');
+		if (strcmp(tmp,control->suffix)) {
 			infilecopy = alloca(strlen(control->infile) + strlen(control->suffix) + 1);
 			strcpy(infilecopy, control->infile);
 			strcat(infilecopy, control->suffix);
 		} else
 			infilecopy = strdupa(control->infile);
+		stat(infilecopy, &fdin_stat);
+		if (!S_ISREG(fdin_stat.st_mode))
+			failure("lrzip only works on regular FILES\n");
 		/* regardless, infilecopy has the input filename */
 	}
 
 	if (!STDOUT && !TEST_ONLY) {
 		/* if output name already set, use it */
-		if (control->outname) {
+		if (control->outname)
 			control->outfile = strdup(control->outname);
-		} else {
+		else {
 			/* default output name from infilecopy
 			 * test if outdir specified. If so, strip path from filename of
 			 * infilecopy, then remove suffix.

--- a/main.c
+++ b/main.c
@@ -594,7 +594,8 @@ int main(int argc, char *argv[])
 			infile = argv[i];
 		else if (!(i == 0 && STDIN))
 			break;
-		if (infile) {
+		if (infile && !(DECOMPRESS || TEST_ONLY)) {
+			/* check that input file exists, unless Decompressing or Test */
 			if ((strcmp(infile, "-") == 0))
 				control->flags |= FLAG_STDIN;
 			else {


### PR DESCRIPTION
Fixes issue #155 
```
$ lrzip -t test.tar
Decompressing...
100%    8880.00 /   8880.00 KB
Average DeCompression Speed:  8.000MB/s
MD5: d0b8180db058a000ad1e28efe1fb7d9c
[OK] - 9093120 bytes                                
Total time: 00:00:00.10
```
```
$ lrzip -d test.tar
Output filename is: test.tar
Failed to create test.tar
File exists
Fatal error - exiting
```
```
lrzip -df test.tar
Overwrite Files
Decompressing...
100%    8880.00 /   8880.00 KB
Average DeCompression Speed:  8.000MB/s
MD5: d0b8180db058a000ad1e28efe1fb7d9c
Output filename is: test.tar: [OK] - 9093120 bytes                                
Total time: 00:00:00.11
```
```
$ lrzip -df test.tar.lrz
Overwrite Files
Decompressing...
100%    8880.00 /   8880.00 KB
Average DeCompression Speed:  8.000MB/s
MD5: d0b8180db058a000ad1e28efe1fb7d9c
Output filename is: test.tar: [OK] - 9093120 bytes                                
Total time: 00:00:00.13
```