### PR TITLE
Revert "BUGFIX: lrzip -d, -t should allow a file with or without an lrz extension and add if necessary"

### DIFF
--- a/lrzip.c
+++ b/lrzip.c
@@ -693,27 +693,26 @@ bool decompress_file(rzip_control *control)
 
 	if (!STDIN && !IS_FROM_FILE) {
 		struct stat fdin_stat;
-		/* make sure infile has an extension. If not, add it
-		 * because manipulations may be made to input filename, set local ptr
-		*/
-		tmp = strrchr(control->infile, '.');
-		if (strcmp(tmp,control->suffix)) {
+
+		stat(control->infile, &fdin_stat);
+		if (!S_ISREG(fdin_stat.st_mode) && (tmp = strrchr(control->infile, '.')) &&
+		    strcmp(tmp,control->suffix)) {
+			/* make sure infile has an extension. If not, add it
+			  * because manipulations may be made to input filename, set local ptr
+			*/
 			infilecopy = alloca(strlen(control->infile) + strlen(control->suffix) + 1);
 			strcpy(infilecopy, control->infile);
 			strcat(infilecopy, control->suffix);
 		} else
 			infilecopy = strdupa(control->infile);
-		stat(infilecopy, &fdin_stat);
-		if (!S_ISREG(fdin_stat.st_mode))
-			failure("lrzip only works on regular FILES\n");
 		/* regardless, infilecopy has the input filename */
 	}
 
 	if (!STDOUT && !TEST_ONLY) {
 		/* if output name already set, use it */
-		if (control->outname)
+		if (control->outname) {
 			control->outfile = strdup(control->outname);
-		else {
+		} else {
 			/* default output name from infilecopy
 			 * test if outdir specified. If so, strip path from filename of
 			 * infilecopy, then remove suffix.

--- a/main.c
+++ b/main.c
@@ -594,8 +594,7 @@ int main(int argc, char *argv[])
 			infile = argv[i];
 		else if (!(i == 0 && STDIN))
 			break;
-		if (infile && !(DECOMPRESS || TEST_ONLY)) {
-			/* check that input file exists, unless Decompressing or Test */
+		if (infile) {
 			if ((strcmp(infile, "-") == 0))
 				control->flags |= FLAG_STDIN;
 			else {


### PR DESCRIPTION
Reverts ckolivas/lrzip#157

Please correct ability to compress any filename.