### PR TITLE
get_fileinfo always shows 0 file offset

### DIFF
--- a/lrzip.c
+++ b/lrzip.c
@@ -1061,7 +1061,7 @@ next_chunk:
 			second_last = last_head;
 			if (unlikely(last_head + ofs > infile_size))
 				failure_goto(("Offset greater than archive size, likely corrupted/truncated archive.\n"), error);
-			if (unlikely(head_off = lseek(fd_in, last_head + ofs, SEEK_SET) == -1))
+			if (unlikely((head_off = lseek(fd_in, last_head + ofs, SEEK_SET)) == -1))
 				fatal_goto(("Failed to seek to header data in get_fileinfo\n"), error);
 			if (unlikely(!get_header_info(control, fd_in, &ctype, &c_len, &u_len,
 					&last_head, chunk_byte)))


### PR DESCRIPTION
Offset always zero because of missing parentheses. Been this way forever. unlikely macro needs additional () for comparison..
```
OLD
Block   Comp    Percent Size
1       lzma    21.4%   22356255 / 104376320    Offset: 0       Head: 22356294
2       lzma    16.8%   17506482 / 104376320    Offset: 0       Head: 39862789
3       lzma    16.8%   17532322 / 104376320    Offset: 0       Head: 57395124

NEW
Block   Comp    Percent Size
1       lzma    21.4%   22356255 / 104376320    Offset: 56      Head: 22356294
2       lzma    16.8%   17506482 / 104376320    Offset: 22356324        Head: 39862789
3       lzma    16.8%   17532322 / 104376320    Offset: 39862819        Head: 57395124
```