### PR TITLE
Fix so that debugger will load and Assembler code will debug.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,9 +133,9 @@ if test x"$ASM" = x"yes"; then
 	ASM_OPT="-I../ASM/x86/"
 	case $host in
 		i?86-*)
-			ASM_OPT="$ASM_OPT -f elf" ;;
+			ASM_OPT="$ASM_OPT -g -f elf" ;;
 		x86_64-*)
-			ASM_OPT="$ASM_OPT -Dx64 -f elf64" ;;
+			ASM_OPT="$ASM_OPT -Dx64 -g -f elf64" ;;
 		*) ASM_OPT= ;;
 	esac
 else

--- a/lzma/C/Makefile.am
+++ b/lzma/C/Makefile.am
@@ -12,8 +12,8 @@ ASM_7z =
 C_S =
 if USE_ASM
   ASM_7z += 7zCrcOpt_asm
-  ASM_S += @top_srcdir@/lzma/ASM/x86/$(ASM_7z).asm
-  ASM_H += @top_srcdir@/lzma/ASM/x86/7zAsm.asm
+  ASM_S += @abs_top_srcdir@/lzma/ASM/x86/$(ASM_7z).asm
+  ASM_H += @abs_top_srcdir@/lzma/ASM/x86/7zAsm.asm
   C_S += 7zCrcT8.c
 else
   C_S += 7zCrc.c 
@@ -24,7 +24,7 @@ noinst_LTLIBRARIES = liblzma.la
 # to prevent an error even if -j## is used.
 liblzma_la_SOURCES = \
 	$(C_S) \
-	7z.Crc.h \
+	7zCrc.h \
 	LzmaDec.h \
 	LzmaEnc.h \
 	LzFind.c \


### PR DESCRIPTION
lzma/C/Makefile.am needs absolute references to assembler code in order to load in debugger.
Fix typo in source list in liblzma_la_SOURCES.
Add debugger switch to assembler.