### PR TITLE
Exit status fixes.

### DIFF
--- a/main.c
+++ b/main.c
@@ -409,9 +409,9 @@ int main(int argc, char *argv[])
 			control->flags |= FLAG_FORCE_REPLACE;
 			break;
 		case 'h':
-		case '?':
 			usage(compat);
-			return -1;
+			exit(0);
+			break;
 		case 'H':
 			control->flags |= FLAG_HASH;
 			break;
@@ -544,6 +544,9 @@ int main(int argc, char *argv[])
 		case '9':
 			control->compression_level = c - '0';
 			break;
+		default:
+			usage(compat);
+			return 2;
 		}
 	}
 


### PR DESCRIPTION
Previously help and all usage errors resulted in exit status 255, which
is unconventional.

Treat help as non-error, and error with status 2 for usage errors to
match more common command behavior.

The exit status of -? changes to that of an usage error, even though it
is listed as one of the help invoking options, due to getopt_long
behavior.