### PR TITLE
Added OpenBSD support

### DIFF
--- a/Lrzip.h
+++ b/Lrzip.h
@@ -29,6 +29,10 @@
 # include <inttypes.h>
 #endif
 
+#if defined (__OpenBSD__) || (__NetBSD__)
+# include <stdarg.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lrzip.c
+++ b/lrzip.c
@@ -90,6 +90,32 @@ i64 get_ram(rzip_control *control)
 
 	return ramsize;
 }
+#elif defined(__OpenBSD__)
+# include <sys/resource.h>
+i64 get_ram(rzip_control *control)
+{
+	struct rlimit rl;
+	i64 ramsize = (i64)sysconf(_SC_PHYS_PAGES) * PAGE_SIZE;
+
+	/* Raise limits all the way to the max */
+
+	if (getrlimit(RLIMIT_DATA, &rl) == -1)
+		fatal_return(("Failed to get limits in get_ram\n"), -1);
+
+	rl.rlim_cur = rl.rlim_max;
+	if (setrlimit(RLIMIT_DATA, &rl) == -1)
+		fatal_return(("Failed to set limits in get_ram\n"), -1);
+
+	/* Declare detected RAM to be either the max RAM available from
+	physical memory or the max RAM allowed by RLIMIT_DATA, whatever
+	is smaller, to prevent the heuristics from selecting
+	compression windows which cause lrzip to go into deep swap */
+
+	if (rl.rlim_max < ramsize)
+		return rl.rlim_max;
+
+	return ramsize;
+}
 #else /* __APPLE__ */
 i64 get_ram(rzip_control *control)
 {

--- a/lrzip_private.h
+++ b/lrzip_private.h
@@ -46,8 +46,6 @@
 
 #ifdef HAVE_ALLOCA_H
 # include <alloca.h>
-#elif defined __GNUC__
-# define alloca __builtin_alloca
 #elif defined _AIX
 # define alloca __alloca
 #elif defined _MSC_VER
@@ -144,7 +142,7 @@ extern int errno;
 #define unlikely(x)	__builtin_expect(!!(x), 0)
 #define __maybe_unused	__attribute__((unused))
 
-#if defined(__MINGW32__) || defined(__CYGWIN__) || defined(__ANDROID__) || defined(__APPLE__)
+#if defined(__MINGW32__) || defined(__CYGWIN__) || defined(__ANDROID__) || defined(__APPLE__) || defined(__OpenBSD__)
 # define ffsll __builtin_ffsll
 #endif
 

--- a/lrzip_private.h
+++ b/lrzip_private.h
@@ -48,6 +48,8 @@
 # include <alloca.h>
 #elif defined _AIX
 # define alloca __alloca
+#elif defined __GNUC__
+# define alloca __builtin_alloca
 #elif defined _MSC_VER
 # include <malloc.h>
 # define alloca _alloca


### PR DESCRIPTION
Added OpenBSD support. Includes a fix for ensuring
lrzip won't try to use more memory than the OS is
willing to grant access to by default