### PR TITLE
fix: use pointer instead of long, which won't work on Windows

### DIFF
--- a/lrzip_private.h
+++ b/lrzip_private.h
@@ -233,7 +233,7 @@ typedef sem_t cksem_t;
 
 #define NO_MD5		(!(HASH_CHECK) && !(HAS_MD5))
 
-#define BITS32		(sizeof(long) == 4)
+#define BITS32		(sizeof(void*) == 4)
 
 #define CTYPE_NONE 3
 #define CTYPE_BZIP2 4


### PR DESCRIPTION
Using `sizeof(long) == 4` to tell whether a platform is 32-bit or not is not reliable since LLP64 platforms exists (and specifically, Win64 API, refernece [here](https://en.cppreference.com/w/cpp/language/types)). This causes problems while trying to port lrzip to such platfroms.