### PR TITLE
Avoid executable stack

### DIFF
--- a/lzma/ASM/x86/7zCrcOpt_asm.asm
+++ b/lzma/ASM/x86/7zCrcOpt_asm.asm
@@ -138,4 +138,10 @@ MY_ENDP
 %ifidn __OUTPUT_FORMAT__,elf
 section .note.GNU-stack noalloc noexec nowrite progbits
 %endif
+%ifidn __OUTPUT_FORMAT__,elf32
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
 


### PR DESCRIPTION
without this patch, the rpmlint check for executable stack failed the build on openSUSE.