### PR TITLE
Mistake in Decompression command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ gets rid of the temporary tarfile. Uses a tempvar `lrzdir` which is unset automa
 #### Decompression for the kind of file from above:
 
 ```bash
-lrzdir=directory; lrunzip -cdivvp `nproc` -o $lrzdir.tar $lrzdir.tar.bzip2-lrz; tar xvf $lrzdir.tar; rm -vf $lrzdir.tar
+lrzdir=directory; lrunzip -cdivvp `nproc` -d -o $lrzdir.tar $lrzdir.tar.bzip2-lrz; tar xvf $lrzdir.tar; rm -vf $lrzdir.tar
 ```
 
 Checks integrity, then decompresses the directory using all of the 


### PR DESCRIPTION
Hello There!,
I Tried the [decompression command](https://github.com/ckolivas/lrzip?tab=readme-ov-file#decompression-for-the-kind-of-file-from-above) given in README and faced an Error caused by .tar intermediate file not being generated.
It was easy to fix after reading the Manual page for this utility and I found
Adding the -d flag to decompression command to fix this. Now this correctly decompresses the file. 

Please let me know if I am mistaken.
Thank You.