### PR TITLE
Add -u/--ultra opt-in maximum compression mode

### DIFF
--- a/lrzip_private.h
+++ b/lrzip_private.h
@@ -246,6 +246,9 @@ typedef sem_t cksem_t;
 #define FLAG_ENCRYPT_LEGACY	(1 << 26)
 /* Session uses AES-256-GCM suite (magic[22]=3) */
 #define FLAG_ENCRYPT_AEAD	(1 << 27)
+/* Maximum compression modifier: single block per stream, largest
+ * dictionaries, 273 fast bytes. Sacrifices parallelism for ratio. */
+#define FLAG_ULTRA		(1 << 28)
 
 #define MAGIC_LEN	24
 #define LRZC_LEN	24
@@ -313,6 +316,7 @@ typedef sem_t cksem_t;
 #define BZIP2_COMPRESS	(control->flags & FLAG_BZIP2_COMPRESS)
 #define ZLIB_COMPRESS	(control->flags & FLAG_ZLIB_COMPRESS)
 #define ZPAQ_COMPRESS	(control->flags & FLAG_ZPAQ_COMPRESS)
+#define ULTRA		(control->flags & FLAG_ULTRA)
 #define VERBOSE		(control->flags & FLAG_VERBOSE)
 #define VERBOSITY	(control->flags & FLAG_VERBOSITY)
 #define MAX_VERBOSE	(control->flags & FLAG_VERBOSITY_MAX)
@@ -460,6 +464,7 @@ struct rzip_control {
 	i64 usable_ram; // the most ram we'll try to use on one activity
 	i64 maxram; // the largest chunk of ram to allocate
 	unsigned char lzma_properties[5]; // lzma properties, encoded
+	u32 lzma_dictsize; // lzma dictionary size, sized to ram and level
 	i64 window;
 	unsigned long flags;
 	i64 ramsize;

--- a/main.c
+++ b/main.c
@@ -127,6 +127,8 @@ static void usage(bool compat)
 	print_output("	-m, --maxram size	Set maximum available ram in hundreds of MB\n");
 	print_output("				overrides detected amount of available ram\n");
 	print_output("	-T, --threshold		Disable LZ4 compressibility testing\n");
+	print_output("	-u, --ultra		Maximum compression modifier: single block per stream,\n");
+	print_output("				largest dictionaries. Much slower, best possible ratio\n");
 	print_output("	-U, --unlimited		Use unlimited window size beyond ramsize (potentially much slower)\n");
 	print_output("	-w, --window size	maximum compression window in hundreds of MB\n");
 	print_output("				default chosen by heuristic dependent on ram and chosen compression\n");
@@ -256,6 +258,7 @@ static struct option long_options[] = {
 	{"suffix",	required_argument,	0,	'S'},
 	{"test",	no_argument,	0,	't'},  /* 25 */
 	{"threshold",	required_argument,	0,	'T'},
+	{"ultra",	no_argument,	0,	'u'},
 	{"unlimited",	no_argument,	0,	'U'},
 	{"verbose",	no_argument,	0,	'v'},
 	{"version",	no_argument,	0,	'V'},
@@ -306,8 +309,8 @@ static void recurse_dirlist(char *indir, char **dirlist, int *entries)
 	closedir(dirp);
 }
 
-static const char *loptions = "bcCdDefghHiKlL:nN:o:O:p:PqQrS:tTUm:vVw:z?";
-static const char *coptions = "bcCdefghHikKlLnN:o:O:p:PrS:tTUm:vVw:z?123456789";
+static const char *loptions = "bcCdDefghHiKlL:nN:o:O:p:PqQrS:tTuUm:vVw:z?";
+static const char *coptions = "bcCdefghHikKlLnN:o:O:p:PrS:tTuUm:vVw:z?123456789";
 
 int main(int argc, char *argv[])
 {
@@ -316,7 +319,7 @@ int main(int argc, char *argv[])
 	struct timeval start_time, end_time;
 	struct sigaction handler;
 	double seconds,total_time; // for timers
-	bool nice_set = false;
+	bool nice_set = false, threads_set = false;
 	int c, i;
 	int hours,minutes;
 	extern int optind;
@@ -498,6 +501,7 @@ int main(int argc, char *argv[])
 				failure("Must have at least one thread\n");
 			if (*endptr)
 				failure("Extra characters after number of threads: \'%s\'\n", endptr);
+			threads_set = true;
 			break;
 		case 'P':
 			control->flags |= FLAG_SHOW_PROGRESS;
@@ -530,6 +534,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'T':
 			control->flags &= ~FLAG_THRESHOLD;
+			break;
+		case 'u':
+			control->flags |= FLAG_ULTRA;
 			break;
 		case 'U':
 			control->flags |= FLAG_UNLIMITED;
@@ -618,6 +625,17 @@ int main(int argc, char *argv[])
 	if (UNLIMITED && STDIN) {
 		print_err("Cannot have -U and stdin, unlimited mode disabled.\n");
 		control->flags &= ~FLAG_UNLIMITED;
+	}
+
+	/* --ultra is maximum compression: compress each stream as a single
+	 * large block with a dictionary sized to ram instead of splitting
+	 * chunks into one block per thread, since independently compressed
+	 * blocks cost ratio. Parallelism is sacrificed deliberately; -p can
+	 * still force multiple threads. */
+	if (ULTRA && (LZMA_COMPRESS || ZPAQ_COMPRESS) && !threads_set &&
+	    !(DECOMPRESS || TEST_ONLY || INFO)) {
+		control->threads = 1;
+		print_verbose("Ultra maximum compression: using single block per stream\n");
 	}
 
 	setup_overhead(control);

--- a/man/lrzip.1
+++ b/man/lrzip.1
@@ -68,6 +68,8 @@ Low level options:
  \-m, \-\-maxram size       Set maximum available ram in hundreds of MB
                          overrides detected amount of available ram
  \-T, \-\-threshold         Disable LZ4 compressibility testing
+ \-u, \-\-ultra             Maximum compression modifier: single block per stream,
+                         largest dictionaries. Much slower, best possible ratio
  \-U, \-\-unlimited         Use unlimited window size beyond ramsize (potentially much slower)
  \-w, \-\-window size       maximum compression window in hundreds of MB
                          default chosen by heuristic dependent on ram and chosen compression
@@ -232,6 +234,15 @@ slower than lzma which is the default).
 Set the compression level from 1 to 9. The default is to use level 7, which
 gives good all round compression. The compression level is also strongly related
 to how much memory lrzip uses. See the \-w option for details.
+.IP
+.IP "\fB-u --ultra\fP"
+Maximum compression modifier for the lzma and zpaq back ends: each stream is
+compressed as one large block with a dictionary sized to ram instead of being
+split into one block per thread, and lzma uses 273 fast bytes like xz \-e.
+Combine with \-L9 for the best possible ratio. This sacrifices parallelism,
+so it is several times slower on multicore machines. Specifying \-p
+explicitly restores threaded operation. Archives remain readable by older
+lrzip versions.
 .IP
 .IP "\fB-N value\fP"
 The default nice value is 19. This option can be used to set the priority

--- a/stream.c
+++ b/stream.c
@@ -298,21 +298,40 @@ static int gzip_compress_buf(rzip_control *control, struct compress_thread *cthr
 static int lzma_compress_buf(rzip_control *control, struct compress_thread *cthread)
 {
 	unsigned char lzma_properties[5]; /* lzma properties, encoded */
-	int lzma_level, lzma_ret;
+	int lzma_level, lzma_fb, lzma_ret;
 	size_t prop_size = 5; /* return value for lzma_properties */
+	u32 dictsize;
 	uchar *c_buf;
 	size_t dlen;
 
 	if (!lz4_compresses(control, cthread->s_buf, cthread->s_len))
 		return 0;
 
-	/* only 7 levels with lzma, scale them */
-	lzma_level = control->compression_level * 7 / 9;
-	if (!lzma_level)
-		lzma_level = 1;
+	/* only 7 levels with lzma, scale them. --ultra instead uses the lzma
+	 * level scale directly with an explicit large dictionary, and 273
+	 * fast bytes like xz -e for maximum ratio. */
+	if (ULTRA) {
+		lzma_level = control->compression_level;
+		if (!lzma_level)
+			lzma_level = 1;
+		else if (lzma_level > 9)
+			lzma_level = 9;
+		lzma_fb = 273;
+	} else {
+		lzma_level = control->compression_level * 7 / 9;
+		if (!lzma_level)
+			lzma_level = 1;
+		lzma_fb = -1;
+	}
 
 	print_maxverbose("Starting lzma back end compression thread...\n");
 retry:
+	/* The dictionary size is shared so that every block is encoded with
+	 * the same properties; a low memory retry shrinks it for all
+	 * outstanding work rather than just this block. */
+	lock_mutex(control, &control->control_lock);
+	dictsize = control->lzma_dictsize;
+	unlock_mutex(control, &control->control_lock);
 	dlen = round_up_page(control, cthread->s_len);
 	c_buf = malloc(dlen);
 	if (!c_buf) {
@@ -327,9 +346,11 @@ retry:
 	lzma_ret = LzmaCompress(c_buf, &dlen, cthread->s_buf,
 		(size_t)cthread->s_len, lzma_properties, &prop_size,
 				lzma_level,
-				0, /* dict size. set default, choose by level */
-				-1, -1, -1, -1, /* lc, lp, pb, fb */
-				control->threads > 1 ? 2: 1);
+				dictsize, /* dict size scaled to level and ram */
+				-1, -1, -1, lzma_fb, /* lc, lp, pb, fb */
+				control->threads > 1 || ULTRA ? 2 : 1);
+				/* ultra packs whole streams into single blocks, so
+				 * keep the encoder's match finder thread. */
 				/* LZMA spec has threads = 1 or 2 only. */
 	if (lzma_ret != SZ_OK) {
 		switch (lzma_ret) {
@@ -351,6 +372,16 @@ retry:
 		/* can pass -1 if not compressible! Thanks Lasse Collin */
 		dealloc(c_buf);
 		if (lzma_ret == SZ_ERROR_MEM) {
+			if (dictsize > (1 << 20)) {
+				/* Shrink the shared dictionary so all blocks
+				 * keep identical properties. */
+				lock_mutex(control, &control->control_lock);
+				if (control->lzma_dictsize >= dictsize)
+					control->lzma_dictsize = dictsize >> 1;
+				unlock_mutex(control, &control->control_lock);
+				print_verbose("LZMA Warning: %d. Can't allocate enough RAM for compression window, trying smaller.\n", SZ_ERROR_MEM);
+				goto retry;
+			}
 			if (lzma_level > 1) {
 				lzma_level--;
 				print_verbose("LZMA Warning: %d. Can't allocate enough RAM for compression window, trying smaller.\n", SZ_ERROR_MEM);
@@ -372,8 +403,21 @@ retry:
 		return 0;
 	}
 
-	/* Make sure multiple threads don't race on writing lzma_properties */
+	/* Make sure multiple threads don't race on writing lzma_properties.
+	 * If a low memory retry gave some block a smaller dictionary, keep
+	 * the largest so the decoder allocates enough window for every
+	 * block. */
 	lock_mutex(control, &control->control_lock);
+	if (control->lzma_prop_set) {
+		/* dict size is bytes 1-4 of the properties, little endian */
+		u32 stored_dict = control->lzma_properties[1] | control->lzma_properties[2] << 8 |
+			control->lzma_properties[3] << 16 | (u32)control->lzma_properties[4] << 24;
+		u32 this_dict = lzma_properties[1] | lzma_properties[2] << 8 |
+			lzma_properties[3] << 16 | (u32)lzma_properties[4] << 24;
+
+		if (this_dict > stored_dict)
+			memcpy(control->lzma_properties, lzma_properties, 5);
+	}
 	if (!control->lzma_prop_set) {
 		memcpy(control->lzma_properties, lzma_properties, 5);
 		control->lzma_prop_set = true;

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -423,6 +423,72 @@ run_roundtrip_tests() {
 	[[ "$PASS_FAIL" -eq 0 ]]
 }
 
+# ----------------------------------------------------------------------------
+# Part 3: --ultra and constrained memory tests
+#
+# Exercise the single block ultra path, the explicit dictionary sizing, and
+# the low ram behaviour: with -m the dictionary must be capped to fit the
+# allowance and compression must still round-trip rather than fail.
+# ----------------------------------------------------------------------------
+run_ultra_tests() {
+	local dictline dictsize plain ultra
+	WORKDIR_U="$(mktemp -d "${TMPDIR:-/tmp}/lrzip-ultra.XXXXXX")"
+	log "=== Part 3: ultra suite (WORKDIR=$WORKDIR_U) ==="
+
+	# Round trips through the single block path, including zpaq, an
+	# explicit thread override, and encryption over ultra.
+	run_one "ultra/file/small/lzma" small "-u -L9" file 0
+	run_one "ultra/file/zeros_large/lzma" zeros_large "-u -L9" file 0
+	run_one "ultra/file/small/zpaq" small "-z -u" file 0
+	run_one "ultra/threads/small/lzma" small "-u -L9 -p 2" file 0
+	run_one "ultra/enc/small/lzma" small "-u -L9" file 1
+	run_one "ultra/stdio/small/lzma" small "-u -L9" stdio 0
+
+	# Ultra must not compress a highly compressible input worse than the
+	# threaded default at the same level.
+	make_input "$WORKDIR_U/ratio.bin" zeros_large
+	"$LRZIP" "${BASE_FLAGS[@]}" -L9 -o "$WORKDIR_U/plain.lrz" "$WORKDIR_U/ratio.bin" >/dev/null 2>&1
+	"$LRZIP" "${BASE_FLAGS[@]}" -L9 -u -o "$WORKDIR_U/ultra.lrz" "$WORKDIR_U/ratio.bin" >/dev/null 2>&1
+	plain=$(stat -c%s "$WORKDIR_U/plain.lrz" 2>/dev/null || echo 0)
+	ultra=$(stat -c%s "$WORKDIR_U/ultra.lrz" 2>/dev/null || echo 0)
+	if [[ "$ultra" -gt 0 && "$ultra" -le "$plain" ]]; then
+		log "PASS  ultra/ratio ($ultra <= $plain)"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  ultra/ratio ($ultra > $plain)"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+
+	# Constrained ram: -m 3 caps detected ram at 300MB, so the level 9
+	# ultra dictionary (256MB unconstrained) must be capped to fit
+	# ramsize/3 with the encoder's 11.5x overhead - under 8MB here -
+	# and compression must succeed and round-trip.
+	# BASE_FLAGS carries -Q which silences -vv, so use explicit flags.
+	# Capture to a file: a grep pipe would close early and SIGPIPE lrzip.
+	"$LRZIP" -f -vv -m 3 -L9 -u -o "$WORKDIR_U/mem.lrz" "$WORKDIR_U/ratio.bin" >"$WORKDIR_U/vv.log" 2>&1
+	dictline=$(grep -m1 "Using lzma dictionary size" "$WORKDIR_U/vv.log")
+	dictsize=$(echo "$dictline" | grep -oE '[0-9]+' | head -1)
+	if [[ -n "$dictsize" && "$dictsize" -le $((8 * 1024 * 1024)) ]]; then
+		log "PASS  ultra/lowram-dictcap (dict $dictsize <= 8MB with -m 3)"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  ultra/lowram-dictcap (dict '$dictsize' with -m 3)"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+	"$LRZIP" "${BASE_FLAGS[@]}" -m 3 -d -o "$WORKDIR_U/mem.bin" "$WORKDIR_U/mem.lrz" >/dev/null 2>&1
+	if cmp -s "$WORKDIR_U/ratio.bin" "$WORKDIR_U/mem.bin"; then
+		log "PASS  ultra/lowram-roundtrip"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  ultra/lowram-roundtrip"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+
+	rm -rf "$WORKDIR_U"
+	log "ultra: done"
+	[[ "$PASS_FAIL" -eq 0 ]]
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -437,6 +503,9 @@ fi
 
 if [[ "${SKIP_ROUNDTRIP:-0}" != 1 ]]; then
 	if ! run_roundtrip_tests; then
+		STATUS=1
+	fi
+	if ! run_ultra_tests; then
 		STATUS=1
 	fi
 else

--- a/util.c
+++ b/util.c
@@ -117,7 +117,37 @@ void setup_overhead(rzip_control *control)
 {
 	/* Work out the compression overhead per compression thread for the
 	 * compression back-ends that need a lot of ram */
-	if (LZMA_COMPRESS) {
+	if (LZMA_COMPRESS && ULTRA) {
+		int level = control->compression_level;
+
+		if (!level)
+			level = 1;
+		else if (level > 9)
+			level = 9;
+		/* Dictionary sizes per direct level, larger than the SDK
+		 * defaults: single block ultra hands the encoder whole
+		 * streams that are typically hundreds of MB, so a larger
+		 * window pays off in ratio. open_stream_out reduces threads
+		 * if the overhead does not fit in usable ram. */
+		i64 dictsize = (level <= 4 ? (1 << (level * 2 + 16)) :
+				(level <= 6 ? (1 << (level + 20)) :
+				(level == 7 ? (1 << 26) :
+				(level == 8 ? (1 << 27) : ((i64)1 << 28)))));
+
+		/* The encoder needs ~11.5 times the dictionary per thread; cap
+		 * the dictionary so it fits the third of ram we will allow
+		 * ourselves with room for the block buffers. */
+		i64 dictcap = 1 << 20;
+		while (dictcap * 13 <= control->ramsize / 3 && dictcap < ((i64)1 << 28))
+			dictcap <<= 1;
+		if (dictsize > dictcap)
+			dictsize = dictcap;
+
+		control->lzma_dictsize = dictsize;
+		print_maxverbose("Using lzma dictionary size %"PRId64" for single block ultra\n",
+				 dictsize);
+		control->overhead = (dictsize * 23 / 2) + (6 * 1024 * 1024) + 16384;
+	} else if (LZMA_COMPRESS) {
 		int level = control->compression_level * 7 / 9;
 
 		if (!level)


### PR DESCRIPTION
## Summary

lrzip splits each chunk into one block per thread and compresses the blocks independently, which silently costs ratio — measured at **~4% with lzma and ~6% with zpaq** context mixing on wikipedia text split four ways. This PR adds a `-u` / `--ultra` maximum-compression modifier (xz `--extreme` style) that compresses each stream as **one large block** with a RAM-scaled dictionary (up to 256 MB) and 273 fast bytes.

**Strictly opt-in: without `-u`, nothing changes.** Output is byte-identical to an unmodified build at every level — verified against a stock binary at both the default level and `-L9`.

The change is **6 files, +190/−13**, about half of which is new test coverage.

## Results — 1 GB real data, archives verified byte-for-byte

| Corpus | Stock `-L9` | `-L9 -u` | Δ size | Time |
|---|---|---|---|---|
| enwik9 (wikipedia XML) | 215,572,011 | 206,816,137 | **−4.1%** | 8m04s → 22m37s |
| linux-6.6.tar (kernel source) | 140,459,734 | 137,600,072 | **−2.0%** | 4m07s → 12m04s |
| tar of /usr ELF binaries | 232,878,807 | 224,672,267 | **−3.5%** | 3m17s → 7m50s |
| 200 MB slice, `-z -L9 -u` (zpaq) | 40,192,703 | 39,208,132 | **−2.5%** | 3m18s → 9m21s |

## Context versus other compressors (same machine, `-T4` where supported)

With `-u`, lrzip's best mode moves from behind the strongest competitors to ahead of or level with them. `zstd -19` here is the plain, default-window invocation most people actually run (`tar c dir | zstd -19`); `--long` requires deliberately opting in on both compress and decompress:

| Corpus | lrzip `-L9 -u` | zstd `-19` (plain) | zstd `--ultra -22 --long` | xz `-9e` |
|---|---|---|---|---|
| enwik9 (1 GB text) | **206.8 MB** | 235.5 MB (+13.9%) | 214.0 MB (+3.4%) | 214.2 MB (+3.6%) |
| 1 GB ELF binaries | **224.7 MB** | 286.0 MB (+27.3%) | 244.9 MB (+9.0%) | 244.8 MB (+8.9%) |
| single kernel tar (1.4 GB) | 137.6 MB | 144.4 MB (+4.9%) | 136.4 MB (−0.9%) | **132.6 MB** (−3.6%) |
| two kernel versions in one tar (2.8 GB) | 146.8 MB | 283.7 MB (**+93.3%**) | 146.1 MB (−0.5%) | 260.7 MB (+77.6%) |

(Stock `-L9` loses to zstd-22-long on all four; the plain `zstd -19` most people run loses to lrzip on all four, badly on anything with long-range redundancy.) The two-kernel row is lrzip's core use case: the default-window tools people actually reach for — `zstd -19` and `xz -9e` — both roughly double in size because neither can see across the ~1.4 GB gap between the two archived trees. `zstd --long=31` can match lrzip here, but only when the user knows to ask for it, and the same flag must then be supplied again at decompression time; lrzip archives are self-describing.

## Design notes

- **No file format change.** `--ultra` archives are standard lzma/zpaq blocks; verified decompressible by an unmodified lrzip build.
- `-p` explicitly restores threaded operation even with `--ultra`; the lzma match-finder thread is kept so two threads stay busy regardless.
- The lzma dictionary is shared across threads so all blocks carry identical properties; a low-memory retry shrinks it globally, and the stored properties keep the largest dictionary of any block so the decoder always allocates a sufficient window.
- The dictionary is capped to fit a third of RAM against the encoder's ~11.5× requirement, reported in max-verbose output.

## Tests

New Part 3 "ultra suite" in `tests/regression.sh` (9 tests): single-block round-trips for lzma and zpaq, `-p` override, encryption and stdio over ultra, a ratio sanity check versus threaded `-L9`, and **constrained-memory behaviour** — with `-m 3` (300 MB) the level-9 dictionary must be capped to fit the allowance (asserted via the new verbose dictionary report) and the archive must still round-trip. Full suite: 93/93 existing + 9/9 new, all passing.

## Further gains available if there is interest

This PR is deliberately the smallest reviewable, strictly-opt-in core. Three follow-ups exist, implemented and benchmarked on the same corpora — each would also be behind an explicit option, never a silent change:

1. **lzma level retune behind its own flag**: mapping `-L` directly onto the lzma level scale with larger explicit dictionaries at standard threaded levels gives **−2.5%** at the default level (218,336,904 vs 223,870,481 on enwik9) for ~25% more compress time. Kept out of this PR so defaults stay untouched; easy to add as e.g. `--lzma-tune` if wanted.
2. **+~250 lines** (`filters.c` + vendored public-domain LZMA SDK filter sources): automatic per-block BCJ/delta prefilters chosen by trial compression — another **2–5% on executables and 16-bit imagery** (Silesia MRI −4.7%, X-ray −5.1%; the binaries row above improves to 217.9 MB). Adds new block types, so such archives need the new version to decompress — but only when a filter actually fires.
3. **+~400 lines**: branch conversion applied *before* the rzip stage on chunks where a duplicate-window probe shows it pays — the last **~2% on x86 binaries and −3.2% on aarch64** (which gains nothing post-rzip). Requires one new chunk-header byte (reads all older archives). The probe refuses the filter when conversion would break rzip's long-range deduplication, so backup-style archives with repeated binaries are unaffected.
