### PR TITLE
Add --filter: opt-in per-block BCJ and delta prefilters for lzma

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,8 @@ libtmplrzip_la_SOURCES = \
   runzip.h \
   stream.c \
   stream.h \
+  filters.c \
+  filters.h \
   util.c \
   util.h \
   md5.c \

--- a/filters.c
+++ b/filters.c
@@ -1,0 +1,157 @@
+/*
+   Copyright (C) 2026 Con Kolivas
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+/* Reversible prefilters: x86/arm64 branch conversion and byte delta.
+ * Branch conversion turns relative call/jump targets into absolute ones so
+ * that repeated calls to the same target become repeated byte sequences;
+ * delta subtracts the byte N before, turning slowly changing sampled data
+ * into small values. All are exact inverses of themselves. */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include "filters.h"
+#include "util.h"
+#include "lzma/C/LzmaLib.h"
+#include "lzma/C/Bra.h"
+#include "lzma/C/Delta.h"
+
+void lrz_filter_stream_init(struct lrz_filter_stream *fs, int kind, bool encode)
+{
+	fs->kind = kind;
+	fs->encode = encode;
+	fs->x86_state = Z7_BRANCH_CONV_ST_X86_STATE_INIT_VAL;
+	fs->pc = 0;
+}
+
+i64 lrz_filter_stream_conv(struct lrz_filter_stream *fs, uchar *buf, i64 len, bool last)
+{
+	Byte delta_state[DELTA_STATE_SIZE];
+	uchar *stop;
+	i64 done;
+
+	switch (fs->kind) {
+	case LRZ_FILTER_X86:
+		if (fs->encode)
+			stop = z7_BranchConvSt_X86_Enc(buf, (SizeT)len, (UInt32)fs->pc, &fs->x86_state);
+		else
+			stop = z7_BranchConvSt_X86_Dec(buf, (SizeT)len, (UInt32)fs->pc, &fs->x86_state);
+		done = last ? len : stop - buf;
+		break;
+	case LRZ_FILTER_ARM64:
+		if (fs->encode)
+			stop = z7_BranchConv_ARM64_Enc(buf, (SizeT)len, (UInt32)fs->pc);
+		else
+			stop = z7_BranchConv_ARM64_Dec(buf, (SizeT)len, (UInt32)fs->pc);
+		done = last ? len : stop - buf;
+		break;
+	case LRZ_FILTER_DELTA1 ... LRZ_FILTER_DELTA4:
+		/* Delta carries its state internally per call; for the
+		 * streaming case the caller must pass whole regions, so it
+		 * is only supported one shot here. */
+		Delta_Init(delta_state);
+		if (fs->encode)
+			Delta_Encode(delta_state, fs->kind - LRZ_FILTER_DELTA1 + 1, buf, (SizeT)len);
+		else
+			Delta_Decode(delta_state, fs->kind - LRZ_FILTER_DELTA1 + 1, buf, (SizeT)len);
+		done = len;
+		break;
+	default:
+		done = len;
+		break;
+	}
+	fs->pc += done;
+	return done;
+}
+
+void lrz_filter_convert_mem(uchar *buf, i64 len, int kind, bool encode)
+{
+	struct lrz_filter_stream fs;
+
+	lrz_filter_stream_init(&fs, kind, encode);
+	lrz_filter_stream_conv(&fs, buf, len, true);
+}
+
+int lrz_filter_trial(rzip_control *control, uchar *sample_area, i64 avail)
+{
+	unsigned char props[5];
+	size_t prop_size = 5, plain_len, best_len, trial_len, sample;
+	int best = LRZ_FILTER_NONE, ret, i;
+	uchar *pristine, *copy, *out;
+	i64 sample_ofs;
+
+	if (avail < (1 << 20))
+		return LRZ_FILTER_NONE;	/* not worth the trials on small data */
+
+	sample = MIN((size_t)avail, (size_t)(1 << 21));
+
+	pristine = malloc(sample);
+	copy = malloc(sample);
+	out = malloc(sample);
+	if (unlikely(!pristine || !copy || !out))
+		goto out;
+
+	/* Sample from the middle, away from headers, 4 byte aligned so the
+	 * arm64 trial sees the same word phase as the full conversion. */
+	sample_ofs = ((avail - (i64)sample) / 2) & ~(i64)3;
+	memcpy(pristine, sample_area + sample_ofs, sample);
+
+	plain_len = sample;
+	ret = LzmaCompress(out, &plain_len, pristine, sample, props, &prop_size,
+			   1, 1 << 20, -1, -1, -1, -1, 1);
+	if (ret != SZ_OK && ret != SZ_ERROR_OUTPUT_EOF)
+		goto out;
+
+	/* Candidates must win by at least this much versus plain so that
+	 * borderline data stays unfiltered */
+	best_len = plain_len - (plain_len / 64);
+
+	for (i = LRZ_FILTER_X86; i <= LRZ_FILTER_MAX; i++) {
+		memcpy(copy, pristine, sample);
+		lrz_filter_convert_mem(copy, sample, i, true);
+		trial_len = sample;
+		prop_size = 5;
+		ret = LzmaCompress(out, &trial_len, copy, sample, props, &prop_size,
+				   1, 1 << 20, -1, -1, -1, -1, 1);
+		if (ret != SZ_OK)
+			continue;
+		if (trial_len < best_len) {
+			best_len = trial_len;
+			best = i;
+		}
+	}
+	print_maxverbose("Filter trial: plain %zu best %zu, chose filter %d\n",
+			 plain_len, best_len, best);
+out:
+	dealloc(pristine);
+	dealloc(copy);
+	dealloc(out);
+	return best;
+}
+
+int lrz_stream_filter_pick(rzip_control *control, uchar *buf, i64 len)
+{
+	if (!control->filter_mode)
+		return LRZ_FILTER_NONE;
+	if (control->filter_mode > 0)
+		return control->filter_mode;
+	return lrz_filter_trial(control, buf, len);
+}

--- a/filters.h
+++ b/filters.h
@@ -1,0 +1,57 @@
+/*
+   Copyright (C) 2026 Con Kolivas
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef LRZIP_FILTERS_H
+#define LRZIP_FILTERS_H
+
+#include "lrzip_private.h"
+
+/* Reversible data transforms applied to backend blocks before compression,
+ * enabled by --filter. Recorded per block in the block type byte. */
+#define LRZ_FILTER_NONE 0
+#define LRZ_FILTER_X86 1
+#define LRZ_FILTER_ARM64 2
+#define LRZ_FILTER_DELTA1 3	/* delta distance 1 */
+#define LRZ_FILTER_DELTA2 4
+#define LRZ_FILTER_DELTA3 5
+#define LRZ_FILTER_DELTA4 6
+#define LRZ_FILTER_MAX LRZ_FILTER_DELTA4
+
+/* Streaming converter state so a filter can be applied or reversed over a
+ * region processed in slices. Feed slices in order; all but the final call
+ * may leave up to 4 unconverted tail bytes for the caller to carry into
+ * the next slice. */
+struct lrz_filter_stream {
+	int kind;
+	bool encode;
+	u32 x86_state;
+	i64 pc;		/* position of buf[0] within the filtered region */
+};
+
+void lrz_filter_stream_init(struct lrz_filter_stream *fs, int kind, bool encode);
+/* Convert buf[0..len) in place; returns the number of bytes fully
+ * converted (== len when last is true). */
+i64 lrz_filter_stream_conv(struct lrz_filter_stream *fs, uchar *buf, i64 len, bool last);
+/* One shot in place conversion of a whole region */
+void lrz_filter_convert_mem(uchar *buf, i64 len, int kind, bool encode);
+/* Trial compress a sample plain and converted with each candidate filter;
+ * returns the winning LRZ_FILTER_* or LRZ_FILTER_NONE. */
+int lrz_filter_trial(rzip_control *control, uchar *sample_area, i64 avail);
+/* Filter for one backend block under control->filter_mode: forced kind,
+ * trial selection for auto, or LRZ_FILTER_NONE when filtering is off. */
+int lrz_stream_filter_pick(rzip_control *control, uchar *buf, i64 len);
+
+#endif

--- a/lrzip.c
+++ b/lrzip.c
@@ -1356,6 +1356,12 @@ next_chunk:
 				print_verbose("gzip");
 			else if (ctype == CTYPE_ZPAQ)
 				print_verbose("zpaq");
+			else if (ctype == CTYPE_LZMA_BCJ)
+				print_verbose("lzma+bcj");
+			else if (ctype == CTYPE_LZMA_BCJ_ARM64)
+				print_verbose("lzma+bcj-arm64");
+			else if (ctype >= CTYPE_LZMA_DELTA1 && ctype <= CTYPE_LZMA_DELTA4)
+				print_verbose("lzma+delta%d", ctype - CTYPE_LZMA_DELTA1 + 1);
 			else
 				print_verbose("Dunno wtf");
 			if (save_ctype == 255)
@@ -1451,6 +1457,12 @@ done:
 		print_output("rzip + gzip\n");
 	else if (save_ctype == CTYPE_ZPAQ)
 		print_output("rzip + zpaq\n");
+	else if (save_ctype == CTYPE_LZMA_BCJ)
+		print_output("rzip + lzma + x86 bcj\n");
+	else if (save_ctype == CTYPE_LZMA_BCJ_ARM64)
+		print_output("rzip + lzma + arm64 bcj\n");
+	else if (save_ctype >= CTYPE_LZMA_DELTA1 && save_ctype <= CTYPE_LZMA_DELTA4)
+		print_output("rzip + lzma + delta %d\n", save_ctype - CTYPE_LZMA_DELTA1 + 1);
 	else
 		print_output("Dunno wtf\n");
 

--- a/lrzip_private.h
+++ b/lrzip_private.h
@@ -271,6 +271,16 @@ typedef sem_t cksem_t;
 #define CTYPE_LZMA 6
 #define CTYPE_GZIP 7
 #define CTYPE_ZPAQ 8
+/* lzma with a reversible filter applied first: x86 or arm64 BCJ branch
+ * conversion for executable code, or byte delta with distance 1-4 for
+ * numeric/sampled data. Only written when --filter is used; the filter is
+ * chosen per block by trial unless one is forced. */
+#define CTYPE_LZMA_BCJ 9
+#define CTYPE_LZMA_BCJ_ARM64 10
+#define CTYPE_LZMA_DELTA1 11
+#define CTYPE_LZMA_DELTA2 12
+#define CTYPE_LZMA_DELTA3 13
+#define CTYPE_LZMA_DELTA4 14
 
 #define PASS_LEN 512
 #define HASH_LEN 64
@@ -465,6 +475,10 @@ struct rzip_control {
 	i64 maxram; // the largest chunk of ram to allocate
 	unsigned char lzma_properties[5]; // lzma properties, encoded
 	u32 lzma_dictsize; // lzma dictionary size, sized to ram and level
+	/* --filter: 0 off, -1 per block trial selection, else the forced
+	 * LRZ_FILTER_* kind. Backend blocks record their filter in the
+	 * block type byte. */
+	int filter_mode;
 	i64 window;
 	unsigned long flags;
 	i64 ramsize;

--- a/lrzip_private.h
+++ b/lrzip_private.h
@@ -246,6 +246,9 @@ typedef sem_t cksem_t;
 #define FLAG_ENCRYPT_LEGACY	(1 << 26)
 /* Session uses AES-256-GCM suite (magic[22]=3) */
 #define FLAG_ENCRYPT_AEAD	(1 << 27)
+/* Maximum compression modifier: single block per stream, largest
+ * dictionaries, 273 fast bytes. Sacrifices parallelism for ratio. */
+#define FLAG_ULTRA		(1 << 28)
 
 #define MAGIC_LEN	24
 #define LRZC_LEN	24
@@ -313,6 +316,7 @@ typedef sem_t cksem_t;
 #define BZIP2_COMPRESS	(control->flags & FLAG_BZIP2_COMPRESS)
 #define ZLIB_COMPRESS	(control->flags & FLAG_ZLIB_COMPRESS)
 #define ZPAQ_COMPRESS	(control->flags & FLAG_ZPAQ_COMPRESS)
+#define ULTRA		(control->flags & FLAG_ULTRA)
 #define VERBOSE		(control->flags & FLAG_VERBOSE)
 #define VERBOSITY	(control->flags & FLAG_VERBOSITY)
 #define MAX_VERBOSE	(control->flags & FLAG_VERBOSITY_MAX)
@@ -460,6 +464,7 @@ struct rzip_control {
 	i64 usable_ram; // the most ram we'll try to use on one activity
 	i64 maxram; // the largest chunk of ram to allocate
 	unsigned char lzma_properties[5]; // lzma properties, encoded
+	u32 lzma_dictsize; // lzma dictionary size, sized to ram and level
 	i64 window;
 	unsigned long flags;
 	i64 ramsize;

--- a/lzma/C/Bra.c
+++ b/lzma/C/Bra.c
@@ -1,0 +1,709 @@
+/* Bra.c -- Branch converters for RISC code
+2024-01-20 : Igor Pavlov : Public domain */
+
+#include "Precomp.h"
+
+#include "Bra.h"
+#include "RotateDefs.h"
+#include "CpuArch.h"
+
+#if defined(MY_CPU_SIZEOF_POINTER) \
+    && ( MY_CPU_SIZEOF_POINTER == 4 \
+      || MY_CPU_SIZEOF_POINTER == 8)
+  #define BR_CONV_USE_OPT_PC_PTR
+#endif
+
+#ifdef BR_CONV_USE_OPT_PC_PTR
+#define BR_PC_INIT  pc -= (UInt32)(SizeT)p;
+#define BR_PC_GET   (pc + (UInt32)(SizeT)p)
+#else
+#define BR_PC_INIT  pc += (UInt32)size;
+#define BR_PC_GET   (pc - (UInt32)(SizeT)(lim - p))
+// #define BR_PC_INIT
+// #define BR_PC_GET   (pc + (UInt32)(SizeT)(p - data))
+#endif
+
+#define BR_CONVERT_VAL(v, c) if (encoding) v += c; else v -= c;
+// #define BR_CONVERT_VAL(v, c) if (!encoding) c = (UInt32)0 - c; v += c;
+
+#define Z7_BRANCH_CONV(name) z7_ ## name
+
+#define Z7_BRANCH_FUNC_MAIN(name) \
+static \
+Z7_FORCE_INLINE \
+Z7_ATTRIB_NO_VECTOR \
+Byte *Z7_BRANCH_CONV(name)(Byte *p, SizeT size, UInt32 pc, int encoding)
+
+#define Z7_BRANCH_FUNC_IMP(name, m, encoding) \
+Z7_NO_INLINE \
+Z7_ATTRIB_NO_VECTOR \
+Byte *m(name)(Byte *data, SizeT size, UInt32 pc) \
+  { return Z7_BRANCH_CONV(name)(data, size, pc, encoding); } \
+
+#ifdef Z7_EXTRACT_ONLY
+#define Z7_BRANCH_FUNCS_IMP(name) \
+  Z7_BRANCH_FUNC_IMP(name, Z7_BRANCH_CONV_DEC_2, 0)
+#else
+#define Z7_BRANCH_FUNCS_IMP(name) \
+  Z7_BRANCH_FUNC_IMP(name, Z7_BRANCH_CONV_DEC_2, 0) \
+  Z7_BRANCH_FUNC_IMP(name, Z7_BRANCH_CONV_ENC_2, 1)
+#endif
+
+#if defined(__clang__)
+#define BR_EXTERNAL_FOR
+#define BR_NEXT_ITERATION  continue;
+#else
+#define BR_EXTERNAL_FOR    for (;;)
+#define BR_NEXT_ITERATION  break;
+#endif
+
+#if defined(__clang__) && (__clang_major__ >= 8) \
+  || defined(__GNUC__) && (__GNUC__ >= 1000) \
+  // GCC is not good for __builtin_expect() here
+  /* || defined(_MSC_VER) && (_MSC_VER >= 1920) */
+  // #define Z7_unlikely [[unlikely]]
+  // #define Z7_LIKELY(x)   (__builtin_expect((x), 1))
+  #define Z7_UNLIKELY(x) (__builtin_expect((x), 0))
+  // #define Z7_likely [[likely]]
+#else
+  // #define Z7_LIKELY(x)   (x)
+  #define Z7_UNLIKELY(x) (x)
+  // #define Z7_likely
+#endif
+
+
+Z7_BRANCH_FUNC_MAIN(BranchConv_ARM64)
+{
+  // Byte *p = data;
+  const Byte *lim;
+  const UInt32 flag = (UInt32)1 << (24 - 4);
+  const UInt32 mask = ((UInt32)1 << 24) - (flag << 1);
+  size &= ~(SizeT)3;
+  // if (size == 0) return p;
+  lim = p + size;
+  BR_PC_INIT
+  pc -= 4;  // because (p) will point to next instruction
+  
+  BR_EXTERNAL_FOR
+  {
+    // Z7_PRAGMA_OPT_DISABLE_LOOP_UNROLL_VECTORIZE
+    for (;;)
+    {
+      UInt32 v;
+      if Z7_UNLIKELY(p == lim)
+        return p;
+      v = GetUi32a(p);
+      p += 4;
+      if Z7_UNLIKELY(((v - 0x94000000) & 0xfc000000) == 0)
+      {
+        UInt32 c = BR_PC_GET >> 2;
+        BR_CONVERT_VAL(v, c)
+        v &= 0x03ffffff;
+        v |= 0x94000000;
+        SetUi32a(p - 4, v)
+        BR_NEXT_ITERATION
+      }
+      // v = rotlFixed(v, 8);  v += (flag << 8) - 0x90;  if Z7_UNLIKELY((v & ((mask << 8) + 0x9f)) == 0)
+      v -= 0x90000000;  if Z7_UNLIKELY((v & 0x9f000000) == 0)
+      {
+        UInt32 z, c;
+        // v = rotrFixed(v, 8);
+        v += flag; if Z7_UNLIKELY(v & mask) continue;
+        z = (v & 0xffffffe0) | (v >> 26);
+        c = (BR_PC_GET >> (12 - 3)) & ~(UInt32)7;
+        BR_CONVERT_VAL(z, c)
+        v &= 0x1f;
+        v |= 0x90000000;
+        v |= z << 26;
+        v |= 0x00ffffe0 & ((z & (((flag << 1) - 1))) - flag);
+        SetUi32a(p - 4, v)
+      }
+    }
+  }
+}
+Z7_BRANCH_FUNCS_IMP(BranchConv_ARM64)
+
+
+Z7_BRANCH_FUNC_MAIN(BranchConv_ARM)
+{
+  // Byte *p = data;
+  const Byte *lim;
+  size &= ~(SizeT)3;
+  lim = p + size;
+  BR_PC_INIT
+  /* in ARM: branch offset is relative to the +2 instructions from current instruction.
+     (p) will point to next instruction */
+  pc += 8 - 4;
+  
+  for (;;)
+  {
+    for (;;)
+    {
+      if Z7_UNLIKELY(p >= lim) { return p; }  p += 4;  if Z7_UNLIKELY(p[-1] == 0xeb) break;
+      if Z7_UNLIKELY(p >= lim) { return p; }  p += 4;  if Z7_UNLIKELY(p[-1] == 0xeb) break;
+    }
+    {
+      UInt32 v = GetUi32a(p - 4);
+      UInt32 c = BR_PC_GET >> 2;
+      BR_CONVERT_VAL(v, c)
+      v &= 0x00ffffff;
+      v |= 0xeb000000;
+      SetUi32a(p - 4, v)
+    }
+  }
+}
+Z7_BRANCH_FUNCS_IMP(BranchConv_ARM)
+
+
+Z7_BRANCH_FUNC_MAIN(BranchConv_PPC)
+{
+  // Byte *p = data;
+  const Byte *lim;
+  size &= ~(SizeT)3;
+  lim = p + size;
+  BR_PC_INIT
+  pc -= 4;  // because (p) will point to next instruction
+  
+  for (;;)
+  {
+    UInt32 v;
+    for (;;)
+    {
+      if Z7_UNLIKELY(p == lim)
+        return p;
+      // v = GetBe32a(p);
+      v = *(UInt32 *)(void *)p;
+      p += 4;
+      // if ((v & 0xfc000003) == 0x48000001) break;
+      // if ((p[-4] & 0xFC) == 0x48 && (p[-1] & 3) == 1) break;
+      if Z7_UNLIKELY(
+          ((v - Z7_CONV_BE_TO_NATIVE_CONST32(0x48000001))
+              & Z7_CONV_BE_TO_NATIVE_CONST32(0xfc000003)) == 0) break;
+    }
+    {
+      v = Z7_CONV_NATIVE_TO_BE_32(v);
+      {
+        UInt32 c = BR_PC_GET;
+        BR_CONVERT_VAL(v, c)
+      }
+      v &= 0x03ffffff;
+      v |= 0x48000000;
+      SetBe32a(p - 4, v)
+    }
+  }
+}
+Z7_BRANCH_FUNCS_IMP(BranchConv_PPC)
+
+
+#ifdef Z7_CPU_FAST_ROTATE_SUPPORTED
+#define BR_SPARC_USE_ROTATE
+#endif
+
+Z7_BRANCH_FUNC_MAIN(BranchConv_SPARC)
+{
+  // Byte *p = data;
+  const Byte *lim;
+  const UInt32 flag = (UInt32)1 << 22;
+  size &= ~(SizeT)3;
+  lim = p + size;
+  BR_PC_INIT
+  pc -= 4;  // because (p) will point to next instruction
+  for (;;)
+  {
+    UInt32 v;
+    for (;;)
+    {
+      if Z7_UNLIKELY(p == lim)
+        return p;
+      /* // the code without GetBe32a():
+      { const UInt32 v = GetUi16a(p) & 0xc0ff; p += 4; if (v == 0x40 || v == 0xc07f) break; }
+      */
+      v = GetBe32a(p);
+      p += 4;
+    #ifdef BR_SPARC_USE_ROTATE
+      v = rotlFixed(v, 2);
+      v += (flag << 2) - 1;
+      if Z7_UNLIKELY((v & (3 - (flag << 3))) == 0)
+    #else
+      v += (UInt32)5 << 29;
+      v ^= (UInt32)7 << 29;
+      v += flag;
+      if Z7_UNLIKELY((v & (0 - (flag << 1))) == 0)
+    #endif
+        break;
+    }
+    {
+      // UInt32 v = GetBe32a(p - 4);
+    #ifndef BR_SPARC_USE_ROTATE
+      v <<= 2;
+    #endif
+      {
+        UInt32 c = BR_PC_GET;
+        BR_CONVERT_VAL(v, c)
+      }
+      v &= (flag << 3) - 1;
+    #ifdef BR_SPARC_USE_ROTATE
+      v -= (flag << 2) - 1;
+      v = rotrFixed(v, 2);
+    #else
+      v -= (flag << 2);
+      v >>= 2;
+      v |= (UInt32)1 << 30;
+    #endif
+      SetBe32a(p - 4, v)
+    }
+  }
+}
+Z7_BRANCH_FUNCS_IMP(BranchConv_SPARC)
+
+
+Z7_BRANCH_FUNC_MAIN(BranchConv_ARMT)
+{
+  // Byte *p = data;
+  Byte *lim;
+  size &= ~(SizeT)1;
+  // if (size == 0) return p;
+  if (size <= 2) return p;
+  size -= 2;
+  lim = p + size;
+  BR_PC_INIT
+  /* in ARM: branch offset is relative to the +2 instructions from current instruction.
+     (p) will point to the +2 instructions from current instruction */
+  // pc += 4 - 4;
+  // if (encoding) pc -= 0xf800 << 1; else pc += 0xf800 << 1;
+  // #define ARMT_TAIL_PROC { goto armt_tail; }
+  #define ARMT_TAIL_PROC { return p; }
+  
+  do
+  {
+    /* in MSVC 32-bit x86 compilers:
+       UInt32 version : it loads value from memory with movzx
+       Byte   version : it loads value to 8-bit register (AL/CL)
+       movzx version is slightly faster in some cpus
+    */
+    unsigned b1;
+    // Byte / unsigned
+    b1 = p[1];
+    // optimized version to reduce one (p >= lim) check:
+    // unsigned a1 = p[1];  b1 = p[3];  p += 2;  if Z7_LIKELY((b1 & (a1 ^ 8)) < 0xf8)
+    for (;;)
+    {
+      unsigned b3; // Byte / UInt32
+      /* (Byte)(b3) normalization can use low byte computations in MSVC.
+         It gives smaller code, and no loss of speed in some compilers/cpus.
+         But new MSVC 32-bit x86 compilers use more slow load
+         from memory to low byte register in that case.
+         So we try to use full 32-bit computations for faster code.
+      */
+      // if (p >= lim) { ARMT_TAIL_PROC }  b3 = b1 + 8;  b1 = p[3];  p += 2;  if ((b3 & b1) >= 0xf8) break;
+      if Z7_UNLIKELY(p >= lim) { ARMT_TAIL_PROC }  b3 = p[3];  p += 2;  if Z7_UNLIKELY((b3 & (b1 ^ 8)) >= 0xf8) break;
+      if Z7_UNLIKELY(p >= lim) { ARMT_TAIL_PROC }  b1 = p[3];  p += 2;  if Z7_UNLIKELY((b1 & (b3 ^ 8)) >= 0xf8) break;
+    }
+    {
+      /* we can adjust pc for (0xf800) to rid of (& 0x7FF) operation.
+         But gcc/clang for arm64 can use bfi instruction for full code here */
+      UInt32 v =
+          ((UInt32)GetUi16a(p - 2) << 11) |
+          ((UInt32)GetUi16a(p) & 0x7FF);
+      /*
+      UInt32 v =
+            ((UInt32)p[1 - 2] << 19)
+          + (((UInt32)p[1] & 0x7) << 8)
+          + (((UInt32)p[-2] << 11))
+          + (p[0]);
+      */
+      p += 2;
+      {
+        UInt32 c = BR_PC_GET >> 1;
+        BR_CONVERT_VAL(v, c)
+      }
+      SetUi16a(p - 4, (UInt16)(((v >> 11) & 0x7ff) | 0xf000))
+      SetUi16a(p - 2, (UInt16)(v | 0xf800))
+      /*
+      p[-4] = (Byte)(v >> 11);
+      p[-3] = (Byte)(0xf0 | ((v >> 19) & 0x7));
+      p[-2] = (Byte)v;
+      p[-1] = (Byte)(0xf8 | (v >> 8));
+      */
+    }
+  }
+  while (p < lim);
+  return p;
+  // armt_tail:
+  // if ((Byte)((lim[1] & 0xf8)) != 0xf0) { lim += 2; }  return lim;
+  // return (Byte *)(lim + ((Byte)((lim[1] ^ 0xf0) & 0xf8) == 0 ? 0 : 2));
+  // return (Byte *)(lim + (((lim[1] ^ ~0xfu) & ~7u) == 0 ? 0 : 2));
+  // return (Byte *)(lim + 2 - (((((unsigned)lim[1] ^ 8) + 8) >> 7) & 2));
+}
+Z7_BRANCH_FUNCS_IMP(BranchConv_ARMT)
+
+
+// #define BR_IA64_NO_INLINE
+
+Z7_BRANCH_FUNC_MAIN(BranchConv_IA64)
+{
+  // Byte *p = data;
+  const Byte *lim;
+  size &= ~(SizeT)15;
+  lim = p + size;
+  pc -= 1 << 4;
+  pc >>= 4 - 1;
+  // pc -= 1 << 1;
+  
+  for (;;)
+  {
+    unsigned m;
+    for (;;)
+    {
+      if Z7_UNLIKELY(p == lim)
+        return p;
+      m = (unsigned)((UInt32)0x334b0000 >> (*p & 0x1e));
+      p += 16;
+      pc += 1 << 1;
+      if (m &= 3)
+        break;
+    }
+    {
+      p += (ptrdiff_t)m * 5 - 20; // negative value is expected here.
+      do
+      {
+        const UInt32 t =
+          #if defined(MY_CPU_X86_OR_AMD64)
+            // we use 32-bit load here to reduce code size on x86:
+            GetUi32(p);
+          #else
+            GetUi16(p);
+          #endif
+        UInt32 z = GetUi32(p + 1) >> m;
+        p += 5;
+        if (((t >> m) & (0x70 << 1)) == 0
+            && ((z - (0x5000000 << 1)) & (0xf000000 << 1)) == 0)
+        {
+          UInt32 v = (UInt32)((0x8fffff << 1) | 1) & z;
+          z ^= v;
+        #ifdef BR_IA64_NO_INLINE
+          v |= (v & ((UInt32)1 << (23 + 1))) >> 3;
+          {
+            UInt32 c = pc;
+            BR_CONVERT_VAL(v, c)
+          }
+          v &= (0x1fffff << 1) | 1;
+        #else
+          {
+            if (encoding)
+            {
+              // pc &= ~(0xc00000 << 1); // we just need to clear at least 2 bits
+              pc &= (0x1fffff << 1) | 1;
+              v += pc;
+            }
+            else
+            {
+              // pc |= 0xc00000 << 1; // we need to set at least 2 bits
+              pc |= ~(UInt32)((0x1fffff << 1) | 1);
+              v -= pc;
+            }
+          }
+          v &= ~(UInt32)(0x600000 << 1);
+        #endif
+          v += (0x700000 << 1);
+          v &= (0x8fffff << 1) | 1;
+          z |= v;
+          z <<= m;
+          SetUi32(p + 1 - 5, z)
+        }
+        m++;
+      }
+      while (m &= 3); // while (m < 4);
+    }
+  }
+}
+Z7_BRANCH_FUNCS_IMP(BranchConv_IA64)
+
+
+#define BR_CONVERT_VAL_ENC(v)  v += BR_PC_GET;
+#define BR_CONVERT_VAL_DEC(v)  v -= BR_PC_GET;
+
+#if 1 && defined(MY_CPU_LE_UNALIGN)
+  #define RISCV_USE_UNALIGNED_LOAD
+#endif
+
+#ifdef RISCV_USE_UNALIGNED_LOAD
+  #define RISCV_GET_UI32(p)      GetUi32(p)
+  #define RISCV_SET_UI32(p, v)   { SetUi32(p, v) }
+#else
+  #define RISCV_GET_UI32(p) \
+    ((UInt32)GetUi16a(p) + \
+    ((UInt32)GetUi16a((p) + 2) << 16))
+  #define RISCV_SET_UI32(p, v) { \
+    SetUi16a(p, (UInt16)(v)) \
+    SetUi16a((p) + 2, (UInt16)(v >> 16)) }
+#endif
+
+#if 1 && defined(MY_CPU_LE)
+  #define RISCV_USE_16BIT_LOAD
+#endif
+
+#ifdef RISCV_USE_16BIT_LOAD
+  #define RISCV_LOAD_VAL(p)  GetUi16a(p)
+#else
+  #define RISCV_LOAD_VAL(p)  (*(p))
+#endif
+
+#define RISCV_INSTR_SIZE  2
+#define RISCV_STEP_1      (4 + RISCV_INSTR_SIZE)
+#define RISCV_STEP_2      4
+#define RISCV_REG_VAL     (2 << 7)
+#define RISCV_CMD_VAL     3
+#if 1
+  // for code size optimization:
+  #define RISCV_DELTA_7F  0x7f
+#else
+  #define RISCV_DELTA_7F  0
+#endif
+
+#define RISCV_CHECK_1(v, b) \
+    (((((b) - RISCV_CMD_VAL) ^ ((v) << 8)) & (0xf8000 + RISCV_CMD_VAL)) == 0)
+
+#if 1
+  #define RISCV_CHECK_2(v, r) \
+    ((((v) - ((RISCV_CMD_VAL << 12) | RISCV_REG_VAL | 8)) \
+           << 18) \
+     < ((r) & 0x1d))
+#else
+  // this branch gives larger code, because
+  // compilers generate larger code for big constants.
+  #define RISCV_CHECK_2(v, r) \
+    ((((v) - ((RISCV_CMD_VAL << 12) | RISCV_REG_VAL)) \
+           & ((RISCV_CMD_VAL << 12) | RISCV_REG_VAL)) \
+     < ((r) & 0x1d))
+#endif
+
+
+#define RISCV_SCAN_LOOP \
+  Byte *lim; \
+  size &= ~(SizeT)(RISCV_INSTR_SIZE - 1); \
+  if (size <= 6) return p; \
+  size -= 6; \
+  lim = p + size; \
+  BR_PC_INIT \
+  for (;;) \
+  { \
+    UInt32 a, v; \
+    /* Z7_PRAGMA_OPT_DISABLE_LOOP_UNROLL_VECTORIZE */ \
+    for (;;) \
+    { \
+      if Z7_UNLIKELY(p >= lim) { return p; } \
+      a = (RISCV_LOAD_VAL(p) ^ 0x10u) + 1; \
+      if ((a & 0x77) == 0) break; \
+      a = (RISCV_LOAD_VAL(p + RISCV_INSTR_SIZE) ^ 0x10u) + 1; \
+      p += RISCV_INSTR_SIZE * 2; \
+      if ((a & 0x77) == 0) \
+      { \
+        p -= RISCV_INSTR_SIZE; \
+        if Z7_UNLIKELY(p >= lim) { return p; } \
+        break; \
+      } \
+    }
+// (xx6f ^ 10) + 1 = xx7f + 1 = xx80       : JAL
+// (xxef ^ 10) + 1 = xxff + 1 = xx00 + 100 : JAL
+// (xx17 ^ 10) + 1 = xx07 + 1 = xx08       : AUIPC
+// (xx97 ^ 10) + 1 = xx87 + 1 = xx88       : AUIPC
+
+Byte * Z7_BRANCH_CONV_ENC(RISCV)(Byte *p, SizeT size, UInt32 pc)
+{
+  RISCV_SCAN_LOOP
+    v = a;
+    a = RISCV_GET_UI32(p);
+#ifndef RISCV_USE_16BIT_LOAD
+    v += (UInt32)p[1] << 8;
+#endif
+
+    if ((v & 8) == 0) // JAL
+    {
+      if ((v - (0x100 /* - RISCV_DELTA_7F */)) & 0xd80)
+      {
+        p += RISCV_INSTR_SIZE;
+        continue;
+      }
+      {
+        v = ((a &    1u << 31) >> 11)
+          | ((a & 0x3ff << 21) >> 20)
+          | ((a &     1 << 20) >> 9)
+          |  (a &  0xff << 12);
+        BR_CONVERT_VAL_ENC(v)
+        // ((v & 1) == 0)
+        // v: bits [1 : 20] contain offset bits
+#if 0 && defined(RISCV_USE_UNALIGNED_LOAD)
+        a &= 0xfff;
+        a |= ((UInt32)(v << 23))
+          |  ((UInt32)(v <<  7) & ((UInt32)0xff << 16))
+          |  ((UInt32)(v >>  5) & ((UInt32)0xf0 << 8));
+        RISCV_SET_UI32(p, a)
+#else // aligned
+#if 0
+        SetUi16a(p, (UInt16)(((v >> 5) & 0xf000) | (a & 0xfff)))
+#else
+        p[1] = (Byte)(((v >> 13) & 0xf0) | ((a >> 8) & 0xf));
+#endif
+
+#if 1 && defined(Z7_CPU_FAST_BSWAP_SUPPORTED) && defined(MY_CPU_LE)
+        v <<= 15;
+        v = Z7_BSWAP32(v);
+        SetUi16a(p + 2, (UInt16)v)
+#else
+        p[2] = (Byte)(v >> 9);
+        p[3] = (Byte)(v >> 1);
+#endif
+#endif // aligned
+      }
+      p += 4;
+      continue;
+    } // JAL
+
+    {
+      // AUIPC
+      if (v & 0xe80)  // (not x0) and (not x2)
+      {
+        const UInt32 b = RISCV_GET_UI32(p + 4);
+        if (RISCV_CHECK_1(v, b))
+        {
+          {
+            const UInt32 temp = (b << 12) | (0x17 + RISCV_REG_VAL);
+            RISCV_SET_UI32(p, temp)
+          }
+          a &= 0xfffff000;
+          {
+#if 1
+          const int t = -1 >> 1;
+          if (t != -1)
+            a += (b >> 20) - ((b >> 19) & 0x1000); // arithmetic right shift emulation
+          else
+#endif
+            a += (UInt32)((Int32)b >> 20); // arithmetic right shift (sign-extension).
+          }
+          BR_CONVERT_VAL_ENC(a)
+#if 1 && defined(Z7_CPU_FAST_BSWAP_SUPPORTED) && defined(MY_CPU_LE)
+          a = Z7_BSWAP32(a);
+          RISCV_SET_UI32(p + 4, a)
+#else
+          SetBe32(p + 4, a)
+#endif
+          p += 8;
+        }
+        else
+          p += RISCV_STEP_1;
+      }
+      else
+      {
+        UInt32 r = a >> 27;
+        if (RISCV_CHECK_2(v, r))
+        {
+          v = RISCV_GET_UI32(p + 4);
+          r = (r << 7) + 0x17 + (v & 0xfffff000);
+          a = (a >> 12) | (v << 20);
+          RISCV_SET_UI32(p, r)
+          RISCV_SET_UI32(p + 4, a)
+          p += 8;
+        }
+        else
+          p += RISCV_STEP_2;
+      }
+    }
+  } // for
+}
+
+
+Byte * Z7_BRANCH_CONV_DEC(RISCV)(Byte *p, SizeT size, UInt32 pc)
+{
+  RISCV_SCAN_LOOP
+#ifdef RISCV_USE_16BIT_LOAD
+    if ((a & 8) == 0)
+    {
+#else
+    v = a;
+    a += (UInt32)p[1] << 8;
+    if ((v & 8) == 0)
+    {
+#endif
+      // JAL
+      a -= 0x100 - RISCV_DELTA_7F;
+      if (a & 0xd80)
+      {
+        p += RISCV_INSTR_SIZE;
+        continue;
+      }
+      {
+        const UInt32 a_old = (a + (0xef - RISCV_DELTA_7F)) & 0xfff;
+#if 0 // unaligned
+        a = GetUi32(p);
+        v = (UInt32)(a >> 23) & ((UInt32)0xff << 1)
+          | (UInt32)(a >>  7) & ((UInt32)0xff << 9)
+#elif 1 && defined(Z7_CPU_FAST_BSWAP_SUPPORTED) && defined(MY_CPU_LE)
+        v = GetUi16a(p + 2);
+        v = Z7_BSWAP32(v) >> 15
+#else
+        v = (UInt32)p[3] << 1
+          | (UInt32)p[2] << 9
+#endif
+          | (UInt32)((a & 0xf000) << 5);
+        BR_CONVERT_VAL_DEC(v)
+        a = a_old
+          | (v << 11 &    1u << 31)
+          | (v << 20 & 0x3ff << 21)
+          | (v <<  9 &     1 << 20)
+          | (v       &  0xff << 12);
+        RISCV_SET_UI32(p, a)
+      }
+      p += 4;
+      continue;
+    } // JAL
+
+    {
+      // AUIPC
+      v = a;
+#if 1 && defined(RISCV_USE_UNALIGNED_LOAD)
+      a = GetUi32(p);
+#else
+      a |= (UInt32)GetUi16a(p + 2) << 16;
+#endif
+      if ((v & 0xe80) == 0)  // x0/x2
+      {
+        const UInt32 r = a >> 27;
+        if (RISCV_CHECK_2(v, r))
+        {
+          UInt32 b;
+#if 1 && defined(Z7_CPU_FAST_BSWAP_SUPPORTED) && defined(MY_CPU_LE)
+          b = RISCV_GET_UI32(p + 4);
+          b = Z7_BSWAP32(b);
+#else
+          b = GetBe32(p + 4);
+#endif
+          v = a >> 12;
+          BR_CONVERT_VAL_DEC(b)
+          a = (r << 7) + 0x17;
+          a += (b + 0x800) & 0xfffff000;
+          v |= b << 20;
+          RISCV_SET_UI32(p, a)
+          RISCV_SET_UI32(p + 4, v)
+          p += 8;
+        }
+        else
+          p += RISCV_STEP_2;
+      }
+      else
+      {
+        const UInt32 b = RISCV_GET_UI32(p + 4);
+        if (!RISCV_CHECK_1(v, b))
+          p += RISCV_STEP_1;
+        else
+        {
+          v = (a & 0xfffff000) | (b >> 20);
+          a = (b << 12) | (0x17 + RISCV_REG_VAL);
+          RISCV_SET_UI32(p, a)
+          RISCV_SET_UI32(p + 4, v)
+          p += 8;
+        }
+      }
+    }
+  } // for
+}

--- a/lzma/C/Bra.h
+++ b/lzma/C/Bra.h
@@ -1,0 +1,105 @@
+/* Bra.h -- Branch converters for executables
+2024-01-20 : Igor Pavlov : Public domain */
+
+#ifndef ZIP7_INC_BRA_H
+#define ZIP7_INC_BRA_H
+
+#include "7zTypes.h"
+
+EXTERN_C_BEGIN
+
+/* #define PPC BAD_PPC_11 // for debug */
+
+#define Z7_BRANCH_CONV_DEC_2(name)  z7_ ## name ## _Dec
+#define Z7_BRANCH_CONV_ENC_2(name)  z7_ ## name ## _Enc
+#define Z7_BRANCH_CONV_DEC(name)    Z7_BRANCH_CONV_DEC_2(BranchConv_ ## name)
+#define Z7_BRANCH_CONV_ENC(name)    Z7_BRANCH_CONV_ENC_2(BranchConv_ ## name)
+#define Z7_BRANCH_CONV_ST_DEC(name) z7_BranchConvSt_ ## name ## _Dec
+#define Z7_BRANCH_CONV_ST_ENC(name) z7_BranchConvSt_ ## name ## _Enc
+
+#define Z7_BRANCH_CONV_DECL(name)    Byte * name(Byte *data, SizeT size, UInt32 pc)
+#define Z7_BRANCH_CONV_ST_DECL(name) Byte * name(Byte *data, SizeT size, UInt32 pc, UInt32 *state)
+
+typedef Z7_BRANCH_CONV_DECL(   (*z7_Func_BranchConv));
+typedef Z7_BRANCH_CONV_ST_DECL((*z7_Func_BranchConvSt));
+
+#define Z7_BRANCH_CONV_ST_X86_STATE_INIT_VAL 0
+Z7_BRANCH_CONV_ST_DECL (Z7_BRANCH_CONV_ST_DEC(X86));
+Z7_BRANCH_CONV_ST_DECL (Z7_BRANCH_CONV_ST_ENC(X86));
+
+#define Z7_BRANCH_FUNCS_DECL(name) \
+Z7_BRANCH_CONV_DECL (Z7_BRANCH_CONV_DEC_2(name)); \
+Z7_BRANCH_CONV_DECL (Z7_BRANCH_CONV_ENC_2(name));
+
+Z7_BRANCH_FUNCS_DECL (BranchConv_ARM64)
+Z7_BRANCH_FUNCS_DECL (BranchConv_ARM)
+Z7_BRANCH_FUNCS_DECL (BranchConv_ARMT)
+Z7_BRANCH_FUNCS_DECL (BranchConv_PPC)
+Z7_BRANCH_FUNCS_DECL (BranchConv_SPARC)
+Z7_BRANCH_FUNCS_DECL (BranchConv_IA64)
+Z7_BRANCH_FUNCS_DECL (BranchConv_RISCV)
+
+/*
+These functions convert data that contain CPU instructions.
+Each such function converts relative addresses to absolute addresses in some
+branch instructions: CALL (in all converters) and JUMP (X86 converter only).
+Such conversion allows to increase compression ratio, if we compress that data.
+
+There are 2 types of converters:
+  Byte * Conv_RISC (Byte *data, SizeT size, UInt32 pc);
+  Byte * ConvSt_X86(Byte *data, SizeT size, UInt32 pc, UInt32 *state);
+Each Converter supports 2 versions: one for encoding
+and one for decoding (_Enc/_Dec postfixes in function name).
+
+In params:
+  data  : data buffer
+  size  : size of data
+  pc    : current virtual Program Counter (Instruction Pointer) value
+In/Out param:
+  state : pointer to state variable (for X86 converter only)
+
+Return:
+  The pointer to position in (data) buffer after last byte that was processed.
+  If the caller calls converter again, it must call it starting with that position.
+  But the caller is allowed to move data in buffer. So pointer to
+  current processed position also will be changed for next call.
+  Also the caller must increase internal (pc) value for next call.
+  
+Each converter has some characteristics: Endian, Alignment, LookAhead.
+  Type   Endian  Alignment  LookAhead
+  
+  X86    little      1          4
+  ARMT   little      2          2
+  RISCV  little      2          6
+  ARM    little      4          0
+  ARM64  little      4          0
+  PPC     big        4          0
+  SPARC   big        4          0
+  IA64   little     16          0
+
+  (data) must be aligned for (Alignment).
+  processed size can be calculated as:
+    SizeT processed = Conv(data, size, pc) - data;
+  if (processed == 0)
+    it means that converter needs more data for processing.
+  If (size < Alignment + LookAhead)
+    then (processed == 0) is allowed.
+
+Example code for conversion in loop:
+  UInt32 pc = 0;
+  size = 0;
+  for (;;)
+  {
+    size += Load_more_input_data(data + size);
+    SizeT processed = Conv(data, size, pc) - data;
+    if (processed == 0 && no_more_input_data_after_size)
+      break; // we stop convert loop
+    data += processed;
+    size -= processed;
+    pc += processed;
+  }
+*/
+
+EXTERN_C_END
+
+#endif

--- a/lzma/C/Bra86.c
+++ b/lzma/C/Bra86.c
@@ -1,0 +1,187 @@
+/* Bra86.c -- Branch converter for X86 code (BCJ)
+2023-04-02 : Igor Pavlov : Public domain */
+
+#include "Precomp.h"
+
+#include "Bra.h"
+#include "CpuArch.h"
+
+
+#if defined(MY_CPU_SIZEOF_POINTER) \
+    && ( MY_CPU_SIZEOF_POINTER == 4 \
+      || MY_CPU_SIZEOF_POINTER == 8)
+  #define BR_CONV_USE_OPT_PC_PTR
+#endif
+
+#ifdef BR_CONV_USE_OPT_PC_PTR
+#define BR_PC_INIT  pc -= (UInt32)(SizeT)p; // (MY_uintptr_t)
+#define BR_PC_GET   (pc + (UInt32)(SizeT)p)
+#else
+#define BR_PC_INIT  pc += (UInt32)size;
+#define BR_PC_GET   (pc - (UInt32)(SizeT)(lim - p))
+// #define BR_PC_INIT
+// #define BR_PC_GET   (pc + (UInt32)(SizeT)(p - data))
+#endif
+
+#define BR_CONVERT_VAL(v, c) if (encoding) v += c; else v -= c;
+// #define BR_CONVERT_VAL(v, c) if (!encoding) c = (UInt32)0 - c; v += c;
+
+#define Z7_BRANCH_CONV_ST(name) z7_BranchConvSt_ ## name
+
+#define BR86_NEED_CONV_FOR_MS_BYTE(b) ((((b) + 1) & 0xfe) == 0)
+
+#ifdef MY_CPU_LE_UNALIGN
+  #define BR86_PREPARE_BCJ_SCAN  const UInt32 v = GetUi32(p) ^ 0xe8e8e8e8;
+  #define BR86_IS_BCJ_BYTE(n)    ((v & ((UInt32)0xfe << (n) * 8)) == 0)
+#else
+  #define BR86_PREPARE_BCJ_SCAN
+  // bad for MSVC X86 (partial write to byte reg):
+  #define BR86_IS_BCJ_BYTE(n)    ((p[n - 4] & 0xfe) == 0xe8)
+  // bad for old MSVC (partial write to byte reg):
+  // #define BR86_IS_BCJ_BYTE(n)    (((*p ^ 0xe8) & 0xfe) == 0)
+#endif
+ 
+static
+Z7_FORCE_INLINE
+Z7_ATTRIB_NO_VECTOR
+Byte *Z7_BRANCH_CONV_ST(X86)(Byte *p, SizeT size, UInt32 pc, UInt32 *state, int encoding)
+{
+  if (size < 5)
+    return p;
+ {
+  // Byte *p = data;
+  const Byte *lim = p + size - 4;
+  unsigned mask = (unsigned)*state;  // & 7;
+#ifdef BR_CONV_USE_OPT_PC_PTR
+  /* if BR_CONV_USE_OPT_PC_PTR is defined: we need to adjust (pc) for (+4),
+        because call/jump offset is relative to the next instruction.
+     if BR_CONV_USE_OPT_PC_PTR is not defined : we don't need to adjust (pc) for (+4),
+         because  BR_PC_GET uses (pc - (lim - p)), and lim was adjusted for (-4) before.
+  */
+  pc += 4;
+#endif
+  BR_PC_INIT
+  goto start;
+
+  for (;; mask |= 4)
+  {
+    // cont: mask |= 4;
+  start:
+    if (p >= lim)
+      goto fin;
+    {
+      BR86_PREPARE_BCJ_SCAN
+      p += 4;
+      if (BR86_IS_BCJ_BYTE(0))  { goto m0; }  mask >>= 1;
+      if (BR86_IS_BCJ_BYTE(1))  { goto m1; }  mask >>= 1;
+      if (BR86_IS_BCJ_BYTE(2))  { goto m2; }  mask = 0;
+      if (BR86_IS_BCJ_BYTE(3))  { goto a3; }
+    }
+    goto main_loop;
+
+  m0: p--;
+  m1: p--;
+  m2: p--;
+    if (mask == 0)
+      goto a3;
+    if (p > lim)
+      goto fin_p;
+   
+    // if (((0x17u >> mask) & 1) == 0)
+    if (mask > 4 || mask == 3)
+    {
+      mask >>= 1;
+      continue; // goto cont;
+    }
+    mask >>= 1;
+    if (BR86_NEED_CONV_FOR_MS_BYTE(p[mask]))
+      continue; // goto cont;
+    // if (!BR86_NEED_CONV_FOR_MS_BYTE(p[3])) continue; // goto cont;
+    {
+      UInt32 v = GetUi32(p);
+      UInt32 c;
+      v += (1 << 24);  if (v & 0xfe000000) continue; // goto cont;
+      c = BR_PC_GET;
+      BR_CONVERT_VAL(v, c)
+      {
+        mask <<= 3;
+        if (BR86_NEED_CONV_FOR_MS_BYTE(v >> mask))
+        {
+          v ^= (((UInt32)0x100 << mask) - 1);
+          #ifdef MY_CPU_X86
+          // for X86 : we can recalculate (c) to reduce register pressure
+            c = BR_PC_GET;
+          #endif
+          BR_CONVERT_VAL(v, c)
+        }
+        mask = 0;
+      }
+      // v = (v & ((1 << 24) - 1)) - (v & (1 << 24));
+      v &= (1 << 25) - 1;  v -= (1 << 24);
+      SetUi32(p, v)
+      p += 4;
+      goto main_loop;
+    }
+
+  main_loop:
+    if (p >= lim)
+      goto fin;
+    for (;;)
+    {
+      BR86_PREPARE_BCJ_SCAN
+      p += 4;
+      if (BR86_IS_BCJ_BYTE(0))  { goto a0; }
+      if (BR86_IS_BCJ_BYTE(1))  { goto a1; }
+      if (BR86_IS_BCJ_BYTE(2))  { goto a2; }
+      if (BR86_IS_BCJ_BYTE(3))  { goto a3; }
+      if (p >= lim)
+        goto fin;
+    }
+  
+  a0: p--;
+  a1: p--;
+  a2: p--;
+  a3:
+    if (p > lim)
+      goto fin_p;
+    // if (!BR86_NEED_CONV_FOR_MS_BYTE(p[3])) continue; // goto cont;
+    {
+      UInt32 v = GetUi32(p);
+      UInt32 c;
+      v += (1 << 24);  if (v & 0xfe000000) continue; // goto cont;
+      c = BR_PC_GET;
+      BR_CONVERT_VAL(v, c)
+      // v = (v & ((1 << 24) - 1)) - (v & (1 << 24));
+      v &= (1 << 25) - 1;  v -= (1 << 24);
+      SetUi32(p, v)
+      p += 4;
+      goto main_loop;
+    }
+  }
+
+fin_p:
+  p--;
+fin:
+  // the following processing for tail is optional and can be commented
+  /*
+  lim += 4;
+  for (; p < lim; p++, mask >>= 1)
+    if ((*p & 0xfe) == 0xe8)
+      break;
+  */
+  *state = (UInt32)mask;
+  return p;
+ }
+}
+
+
+#define Z7_BRANCH_CONV_ST_FUNC_IMP(name, m, encoding) \
+Z7_NO_INLINE \
+Z7_ATTRIB_NO_VECTOR \
+Byte *m(name)(Byte *data, SizeT size, UInt32 pc, UInt32 *state) \
+  { return Z7_BRANCH_CONV_ST(name)(data, size, pc, state, encoding); }
+
+Z7_BRANCH_CONV_ST_FUNC_IMP(X86, Z7_BRANCH_CONV_ST_DEC, 0)
+#ifndef Z7_EXTRACT_ONLY
+Z7_BRANCH_CONV_ST_FUNC_IMP(X86, Z7_BRANCH_CONV_ST_ENC, 1)
+#endif

--- a/lzma/C/Delta.c
+++ b/lzma/C/Delta.c
@@ -1,0 +1,169 @@
+/* Delta.c -- Delta converter
+2021-02-09 : Igor Pavlov : Public domain */
+
+#include "Precomp.h"
+
+#include "Delta.h"
+
+void Delta_Init(Byte *state)
+{
+  unsigned i;
+  for (i = 0; i < DELTA_STATE_SIZE; i++)
+    state[i] = 0;
+}
+
+
+void Delta_Encode(Byte *state, unsigned delta, Byte *data, SizeT size)
+{
+  Byte temp[DELTA_STATE_SIZE];
+
+  if (size == 0)
+    return;
+
+  {
+    unsigned i = 0;
+    do
+      temp[i] = state[i];
+    while (++i != delta);
+  }
+
+  if (size <= delta)
+  {
+    unsigned i = 0, k;
+    do
+    {
+      Byte b = *data;
+      *data++ = (Byte)(b - temp[i]);
+      temp[i] = b;
+    }
+    while (++i != size);
+    
+    k = 0;
+    
+    do
+    {
+      if (i == delta)
+        i = 0;
+      state[k] = temp[i++];
+    }
+    while (++k != delta);
+    
+    return;
+  }
+    
+  {
+    Byte *p = data + size - delta;
+    {
+      unsigned i = 0;
+      do
+        state[i] = *p++;
+      while (++i != delta);
+    }
+    {
+      const Byte *lim = data + delta;
+      ptrdiff_t dif = -(ptrdiff_t)delta;
+      
+      if (((ptrdiff_t)size + dif) & 1)
+      {
+        --p;  *p = (Byte)(*p - p[dif]);
+      }
+
+      while (p != lim)
+      {
+        --p;  *p = (Byte)(*p - p[dif]);
+        --p;  *p = (Byte)(*p - p[dif]);
+      }
+      
+      dif = -dif;
+      
+      do
+      {
+        --p;  *p = (Byte)(*p - temp[--dif]);
+      }
+      while (dif != 0);
+    }
+  }
+}
+
+
+void Delta_Decode(Byte *state, unsigned delta, Byte *data, SizeT size)
+{
+  unsigned i;
+  const Byte *lim;
+
+  if (size == 0)
+    return;
+  
+  i = 0;
+  lim = data + size;
+  
+  if (size <= delta)
+  {
+    do
+      *data = (Byte)(*data + state[i++]);
+    while (++data != lim);
+
+    for (; delta != i; state++, delta--)
+      *state = state[i];
+    data -= i;
+  }
+  else
+  {
+    /*
+    #define B(n) b ## n
+    #define I(n) Byte B(n) = state[n];
+    #define U(n) { B(n) = (Byte)((B(n)) + *data++); data[-1] = (B(n)); }
+    #define F(n) if (data != lim) { U(n) }
+
+    if (delta == 1)
+    {
+      I(0)
+      if ((lim - data) & 1) { U(0) }
+      while (data != lim) { U(0) U(0) }
+      data -= 1;
+    }
+    else if (delta == 2)
+    {
+      I(0) I(1)
+      lim -= 1; while (data < lim) { U(0) U(1) }
+      lim += 1; F(0)
+      data -= 2;
+    }
+    else if (delta == 3)
+    {
+      I(0) I(1) I(2)
+      lim -= 2; while (data < lim) { U(0) U(1) U(2) }
+      lim += 2; F(0) F(1)
+      data -= 3;
+    }
+    else if (delta == 4)
+    {
+      I(0) I(1) I(2) I(3)
+      lim -= 3; while (data < lim) { U(0) U(1) U(2) U(3) }
+      lim += 3; F(0) F(1) F(2)
+      data -= 4;
+    }
+    else
+    */
+    {
+      do
+      {
+        *data = (Byte)(*data + state[i++]);
+        data++;
+      }
+      while (i != delta);
+  
+      {
+        ptrdiff_t dif = -(ptrdiff_t)delta;
+        do
+          *data = (Byte)(*data + data[dif]);
+        while (++data != lim);
+        data += dif;
+      }
+    }
+  }
+
+  do
+    *state++ = *data;
+  while (++data != lim);
+}

--- a/lzma/C/Delta.h
+++ b/lzma/C/Delta.h
@@ -1,0 +1,19 @@
+/* Delta.h -- Delta converter
+2023-03-03 : Igor Pavlov : Public domain */
+
+#ifndef ZIP7_INC_DELTA_H
+#define ZIP7_INC_DELTA_H
+
+#include "7zTypes.h"
+
+EXTERN_C_BEGIN
+
+#define DELTA_STATE_SIZE 256
+
+void Delta_Init(Byte *state);
+void Delta_Encode(Byte *state, unsigned delta, Byte *data, SizeT size);
+void Delta_Decode(Byte *state, unsigned delta, Byte *data, SizeT size);
+
+EXTERN_C_END
+
+#endif

--- a/lzma/C/Makefile.am
+++ b/lzma/C/Makefile.am
@@ -19,7 +19,12 @@ liblzma_la_SOURCES = \
 	7zCrcOpt.c \
 	Alloc.c \
 	Alloc.h \
+	Bra.h \
+	Bra.c \
+	Bra86.c \
 	Compiler.h \
+	Delta.c \
+	Delta.h \
 	CpuArch.c \
 	CpuArch.h \
 	LzFind.c \
@@ -35,6 +40,7 @@ liblzma_la_SOURCES = \
 	LzmaLib.c \
 	LzmaLib.h \
 	Precomp.h \
+	RotateDefs.h \
 	Threads.c \
 	Threads.h \
 	7zTypes.h \

--- a/lzma/C/RotateDefs.h
+++ b/lzma/C/RotateDefs.h
@@ -1,0 +1,50 @@
+/* RotateDefs.h -- Rotate functions
+2023-06-18 : Igor Pavlov : Public domain */
+
+#ifndef ZIP7_INC_ROTATE_DEFS_H
+#define ZIP7_INC_ROTATE_DEFS_H
+
+#ifdef _MSC_VER
+
+#include <stdlib.h>
+
+/* don't use _rotl with old MINGW. It can insert slow call to function. */
+ 
+/* #if (_MSC_VER >= 1200) */
+#pragma intrinsic(_rotl)
+#pragma intrinsic(_rotr)
+/* #endif */
+
+#define rotlFixed(x, n) _rotl((x), (n))
+#define rotrFixed(x, n) _rotr((x), (n))
+
+#if (_MSC_VER >= 1300)
+#define Z7_ROTL64(x, n) _rotl64((x), (n))
+#define Z7_ROTR64(x, n) _rotr64((x), (n))
+#else
+#define Z7_ROTL64(x, n) (((x) << (n)) | ((x) >> (64 - (n))))
+#define Z7_ROTR64(x, n) (((x) >> (n)) | ((x) << (64 - (n))))
+#endif
+
+#else
+
+/* new compilers can translate these macros to fast commands. */
+
+#if defined(__clang__) && (__clang_major__ >= 4) \
+  || defined(__GNUC__) && (__GNUC__ >= 5)
+/* GCC 4.9.0 and clang 3.5 can recognize more correct version: */
+#define rotlFixed(x, n) (((x) << (n)) | ((x) >> (-(n) & 31)))
+#define rotrFixed(x, n) (((x) >> (n)) | ((x) << (-(n) & 31)))
+#define Z7_ROTL64(x, n) (((x) << (n)) | ((x) >> (-(n) & 63)))
+#define Z7_ROTR64(x, n) (((x) >> (n)) | ((x) << (-(n) & 63)))
+#else
+/* for old GCC / clang: */
+#define rotlFixed(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
+#define rotrFixed(x, n) (((x) >> (n)) | ((x) << (32 - (n))))
+#define Z7_ROTL64(x, n) (((x) << (n)) | ((x) >> (64 - (n))))
+#define Z7_ROTR64(x, n) (((x) >> (n)) | ((x) << (64 - (n))))
+#endif
+
+#endif
+
+#endif

--- a/main.c
+++ b/main.c
@@ -127,6 +127,8 @@ static void usage(bool compat)
 	print_output("	-m, --maxram size	Set maximum available ram in hundreds of MB\n");
 	print_output("				overrides detected amount of available ram\n");
 	print_output("	-T, --threshold		Disable LZ4 compressibility testing\n");
+	print_output("	-u, --ultra		Maximum compression modifier: single block per stream,\n");
+	print_output("				largest dictionaries. Much slower, best possible ratio\n");
 	print_output("	-U, --unlimited		Use unlimited window size beyond ramsize (potentially much slower)\n");
 	print_output("	-w, --window size	maximum compression window in hundreds of MB\n");
 	print_output("				default chosen by heuristic dependent on ram and chosen compression\n");
@@ -256,6 +258,7 @@ static struct option long_options[] = {
 	{"suffix",	required_argument,	0,	'S'},
 	{"test",	no_argument,	0,	't'},  /* 25 */
 	{"threshold",	required_argument,	0,	'T'},
+	{"ultra",	no_argument,	0,	'u'},
 	{"unlimited",	no_argument,	0,	'U'},
 	{"verbose",	no_argument,	0,	'v'},
 	{"version",	no_argument,	0,	'V'},
@@ -306,8 +309,8 @@ static void recurse_dirlist(char *indir, char **dirlist, int *entries)
 	closedir(dirp);
 }
 
-static const char *loptions = "bcCdDefghHiKlL:nN:o:O:p:PqQrS:tTUm:vVw:z?";
-static const char *coptions = "bcCdefghHikKlLnN:o:O:p:PrS:tTUm:vVw:z?123456789";
+static const char *loptions = "bcCdDefghHiKlL:nN:o:O:p:PqQrS:tTuUm:vVw:z?";
+static const char *coptions = "bcCdefghHikKlLnN:o:O:p:PrS:tTuUm:vVw:z?123456789";
 
 int main(int argc, char *argv[])
 {
@@ -316,7 +319,7 @@ int main(int argc, char *argv[])
 	struct timeval start_time, end_time;
 	struct sigaction handler;
 	double seconds,total_time; // for timers
-	bool nice_set = false;
+	bool nice_set = false, threads_set = false;
 	int c, i;
 	int hours,minutes;
 	extern int optind;
@@ -498,6 +501,7 @@ int main(int argc, char *argv[])
 				failure("Must have at least one thread\n");
 			if (*endptr)
 				failure("Extra characters after number of threads: \'%s\'\n", endptr);
+			threads_set = true;
 			break;
 		case 'P':
 			control->flags |= FLAG_SHOW_PROGRESS;
@@ -530,6 +534,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'T':
 			control->flags &= ~FLAG_THRESHOLD;
+			break;
+		case 'u':
+			control->flags |= FLAG_ULTRA;
 			break;
 		case 'U':
 			control->flags |= FLAG_UNLIMITED;
@@ -618,6 +625,17 @@ int main(int argc, char *argv[])
 	if (UNLIMITED && STDIN) {
 		print_err("Cannot have -U and stdin, unlimited mode disabled.\n");
 		control->flags &= ~FLAG_UNLIMITED;
+	}
+
+	/* --ultra is maximum compression: compress each stream as a single
+	 * large block with a dictionary sized to ram instead of splitting
+	 * chunks into one block per thread, since independently compressed
+	 * blocks cost ratio. Parallelism is sacrificed deliberately; -p can
+	 * still force multiple threads. */
+	if (ULTRA && (LZMA_COMPRESS || ZPAQ_COMPRESS) && !threads_set &&
+	    !(DECOMPRESS || TEST_ONLY || INFO)) {
+		control->threads = 1;
+		print_verbose("Ultra maximum compression: using single block per stream\n");
 	}
 
 	setup_overhead(control);

--- a/main.c
+++ b/main.c
@@ -58,6 +58,7 @@
 #include "lrzip_core.h"
 #include "util.h"
 #include "stream.h"
+#include "filters.h"
 
 /* needed for CRC routines */
 #include "lzma/C/7zCrc.h"
@@ -127,8 +128,12 @@ static void usage(bool compat)
 	print_output("	-m, --maxram size	Set maximum available ram in hundreds of MB\n");
 	print_output("				overrides detected amount of available ram\n");
 	print_output("	-T, --threshold		Disable LZ4 compressibility testing\n");
+	print_output("	    --filter[=TYPE]	Reversible prefilter on lzma blocks. TYPE is auto (default),\n");
+	print_output("				x86, arm64, delta1 .. delta4, or none. auto trial\n");
+	print_output("				compresses a sample of each block and picks the winner\n");
 	print_output("	-u, --ultra		Maximum compression modifier: single block per stream,\n");
-	print_output("				largest dictionaries. Much slower, best possible ratio\n");
+	print_output("				largest dictionaries, automatic prefilters. Much slower,\n");
+	print_output("				best possible ratio\n");
 	print_output("	-U, --unlimited		Use unlimited window size beyond ramsize (potentially much slower)\n");
 	print_output("	-w, --window size	maximum compression window in hundreds of MB\n");
 	print_output("				default chosen by heuristic dependent on ram and chosen compression\n");
@@ -234,6 +239,7 @@ static struct option long_options[] = {
 	{"delete",	no_argument,	0,	'D'},
 	{"encrypt",	optional_argument,	0,	'e'}, /* 5 */
 	{"legacy-encrypt",	no_argument,	0,	'E'},
+	{"filter",	optional_argument,	0,	'F'},
 	{"force",	no_argument,	0,	'f'},
 	{"gzip",	no_argument,	0,	'g'},
 	{"help",	no_argument,	0,	'h'},
@@ -319,7 +325,7 @@ int main(int argc, char *argv[])
 	struct timeval start_time, end_time;
 	struct sigaction handler;
 	double seconds,total_time; // for timers
-	bool nice_set = false, threads_set = false;
+	bool nice_set = false, threads_set = false, filter_set = false;
 	int c, i;
 	int hours,minutes;
 	extern int optind;
@@ -428,6 +434,22 @@ int main(int argc, char *argv[])
 			break;
 		case 'f':
 			control->flags |= FLAG_FORCE_REPLACE;
+			break;
+		case 'F':							/* --filter, long option only */
+			if (!optarg || !strcmp(optarg, "auto"))
+				control->filter_mode = -1;
+			else if (!strcmp(optarg, "none"))
+				control->filter_mode = 0;
+			else if (!strcmp(optarg, "x86"))
+				control->filter_mode = LRZ_FILTER_X86;
+			else if (!strcmp(optarg, "arm64"))
+				control->filter_mode = LRZ_FILTER_ARM64;
+			else if (!strncmp(optarg, "delta", 5) && strlen(optarg) == 6 &&
+				 optarg[5] >= '1' && optarg[5] <= '4')
+				control->filter_mode = LRZ_FILTER_DELTA1 + optarg[5] - '1';
+			else
+				failure("Invalid --filter type '%s': use auto, x86, arm64, delta1 .. delta4 or none\n", optarg);
+			filter_set = true;
 			break;
 		case 'h':
 			usage(compat);
@@ -637,6 +659,20 @@ int main(int argc, char *argv[])
 		control->threads = 1;
 		print_verbose("Ultra maximum compression: using single block per stream\n");
 	}
+
+	/* Maximum compression also means the automatic prefilters, unless
+	 * the user chose explicitly; --filter=none restores plain lzma
+	 * blocks under -u. */
+	if (ULTRA && LZMA_COMPRESS && !filter_set &&
+	    !(DECOMPRESS || TEST_ONLY || INFO)) {
+		control->filter_mode = -1;
+		print_verbose("Ultra maximum compression: enabling automatic prefilters\n");
+	}
+
+	/* The prefilters are only wired into the lzma back end; they are
+	 * chosen per block and recorded in the block type byte. */
+	if (control->filter_mode && !(DECOMPRESS || TEST_ONLY || INFO) && !LZMA_COMPRESS)
+		failure("--filter only works with the lzma back end\n");
 
 	setup_overhead(control);
 

--- a/man/lrzip.1
+++ b/man/lrzip.1
@@ -68,6 +68,8 @@ Low level options:
  \-m, \-\-maxram size       Set maximum available ram in hundreds of MB
                          overrides detected amount of available ram
  \-T, \-\-threshold         Disable LZ4 compressibility testing
+ \-u, \-\-ultra             Maximum compression modifier: single block per stream,
+                         largest dictionaries. Much slower, best possible ratio
  \-U, \-\-unlimited         Use unlimited window size beyond ramsize (potentially much slower)
  \-w, \-\-window size       maximum compression window in hundreds of MB
                          default chosen by heuristic dependent on ram and chosen compression
@@ -232,6 +234,15 @@ slower than lzma which is the default).
 Set the compression level from 1 to 9. The default is to use level 7, which
 gives good all round compression. The compression level is also strongly related
 to how much memory lrzip uses. See the \-w option for details.
+.IP
+.IP "\fB-u --ultra\fP"
+Maximum compression modifier for the lzma and zpaq back ends: each stream is
+compressed as one large block with a dictionary sized to ram instead of being
+split into one block per thread, and lzma uses 273 fast bytes like xz \-e.
+Combine with \-L9 for the best possible ratio. This sacrifices parallelism,
+so it is several times slower on multicore machines. Specifying \-p
+explicitly restores threaded operation. Archives remain readable by older
+lrzip versions.
 .IP
 .IP "\fB-N value\fP"
 The default nice value is 19. This option can be used to set the priority

--- a/man/lrzip.1
+++ b/man/lrzip.1
@@ -68,8 +68,11 @@ Low level options:
  \-m, \-\-maxram size       Set maximum available ram in hundreds of MB
                          overrides detected amount of available ram
  \-T, \-\-threshold         Disable LZ4 compressibility testing
+     \-\-filter[=TYPE]     Reversible prefilter on lzma blocks. TYPE is auto (default),
+                         x86, arm64, delta1 .. delta4, or none
  \-u, \-\-ultra             Maximum compression modifier: single block per stream,
-                         largest dictionaries. Much slower, best possible ratio
+                         largest dictionaries, automatic prefilters. Much slower,
+                         best possible ratio
  \-U, \-\-unlimited         Use unlimited window size beyond ramsize (potentially much slower)
  \-w, \-\-window size       maximum compression window in hundreds of MB
                          default chosen by heuristic dependent on ram and chosen compression
@@ -239,10 +242,13 @@ to how much memory lrzip uses. See the \-w option for details.
 Maximum compression modifier for the lzma and zpaq back ends: each stream is
 compressed as one large block with a dictionary sized to ram instead of being
 split into one block per thread, and lzma uses 273 fast bytes like xz \-e.
-Combine with \-L9 for the best possible ratio. This sacrifices parallelism,
-so it is several times slower on multicore machines. Specifying \-p
-explicitly restores threaded operation. Archives remain readable by older
-lrzip versions.
+With the lzma back end it also enables the automatic prefilters, as if
+\fB\-\-filter\fP had been given; pass \fB\-\-filter=none\fP to keep plain
+blocks. Combine with \-L9 for the best possible ratio. This sacrifices
+parallelism, so it is several times slower on multicore machines. Specifying
+\-p explicitly restores threaded operation. Blocks a prefilter was applied
+to require this lrzip version or later to decompress; with
+\fB\-\-filter=none\fP archives remain readable by older lrzip versions.
 .IP
 .IP "\fB-N value\fP"
 The default nice value is 19. This option can be used to set the priority
@@ -265,6 +271,22 @@ block fails to be compressed by the very fast LZ4, lrzip will not attempt to
 compress that block with the slower compressor, thereby saving time. If this
 option is enabled, it will bypass the LZ4 testing and attempt to compress each
 block regardless.
+.IP
+.IP "\fB--filter[=TYPE]\fP"
+Apply a reversible prefilter to each lzma backend block before compression.
+Branch conversion (x86 or arm64 BCJ) turns relative call targets in executable
+code into absolute ones so repeated calls to the same function become repeated
+byte sequences, and byte delta (distance 1 to 4) turns slowly changing sampled
+data such as 16 bit imagery into small values. With no TYPE or with auto, a
+sample of each block is trial compressed plain and with each candidate filter
+and the winner is only used when it is clearly smaller, so unsuitable data is
+left alone; a specific TYPE forces that filter on every block, and none
+disables filtering (useful under \-u, which implies \-\-filter for lzma
+unless one is given explicitly). The chosen filter is recorded per block and
+reversed automatically on decompression.
+Archives written without filtering are unchanged and remain readable by
+older lrzip versions; blocks a filter was applied to require this version or
+later to decompress.
 .IP
 .IP "\fB-U \fP"
 Unlimited window size\&. If this option is set, and the file being compressed

--- a/stream.c
+++ b/stream.c
@@ -298,21 +298,40 @@ static int gzip_compress_buf(rzip_control *control, struct compress_thread *cthr
 static int lzma_compress_buf(rzip_control *control, struct compress_thread *cthread)
 {
 	unsigned char lzma_properties[5]; /* lzma properties, encoded */
-	int lzma_level, lzma_ret;
+	int lzma_level, lzma_fb, lzma_ret;
 	size_t prop_size = 5; /* return value for lzma_properties */
+	u32 dictsize;
 	uchar *c_buf;
 	size_t dlen;
 
 	if (!lz4_compresses(control, cthread->s_buf, cthread->s_len))
 		return 0;
 
-	/* only 7 levels with lzma, scale them */
-	lzma_level = control->compression_level * 7 / 9;
-	if (!lzma_level)
-		lzma_level = 1;
+	/* only 7 levels with lzma, scale them. --ultra instead uses the lzma
+	 * level scale directly with an explicit large dictionary, and 273
+	 * fast bytes like xz -e for maximum ratio. */
+	if (ULTRA) {
+		lzma_level = control->compression_level;
+		if (!lzma_level)
+			lzma_level = 1;
+		else if (lzma_level > 9)
+			lzma_level = 9;
+		lzma_fb = 273;
+	} else {
+		lzma_level = control->compression_level * 7 / 9;
+		if (!lzma_level)
+			lzma_level = 1;
+		lzma_fb = -1;
+	}
 
 	print_maxverbose("Starting lzma back end compression thread...\n");
 retry:
+	/* The dictionary size is shared so that every block is encoded with
+	 * the same properties; a low memory retry shrinks it for all
+	 * outstanding work rather than just this block. */
+	lock_mutex(control, &control->control_lock);
+	dictsize = control->lzma_dictsize;
+	unlock_mutex(control, &control->control_lock);
 	dlen = round_up_page(control, cthread->s_len);
 	c_buf = malloc(dlen);
 	if (!c_buf) {
@@ -327,9 +346,11 @@ retry:
 	lzma_ret = LzmaCompress(c_buf, &dlen, cthread->s_buf,
 		(size_t)cthread->s_len, lzma_properties, &prop_size,
 				lzma_level,
-				0, /* dict size. set default, choose by level */
-				-1, -1, -1, -1, /* lc, lp, pb, fb */
-				control->threads > 1 ? 2: 1);
+				dictsize, /* dict size scaled to level and ram */
+				-1, -1, -1, lzma_fb, /* lc, lp, pb, fb */
+				control->threads > 1 || ULTRA ? 2 : 1);
+				/* ultra packs whole streams into single blocks, so
+				 * keep the encoder's match finder thread. */
 				/* LZMA spec has threads = 1 or 2 only. */
 	if (lzma_ret != SZ_OK) {
 		switch (lzma_ret) {
@@ -351,6 +372,16 @@ retry:
 		/* can pass -1 if not compressible! Thanks Lasse Collin */
 		dealloc(c_buf);
 		if (lzma_ret == SZ_ERROR_MEM) {
+			if (dictsize > (1 << 20)) {
+				/* Shrink the shared dictionary so all blocks
+				 * keep identical properties. */
+				lock_mutex(control, &control->control_lock);
+				if (control->lzma_dictsize >= dictsize)
+					control->lzma_dictsize = dictsize >> 1;
+				unlock_mutex(control, &control->control_lock);
+				print_verbose("LZMA Warning: %d. Can't allocate enough RAM for compression window, trying smaller.\n", SZ_ERROR_MEM);
+				goto retry;
+			}
 			if (lzma_level > 1) {
 				lzma_level--;
 				print_verbose("LZMA Warning: %d. Can't allocate enough RAM for compression window, trying smaller.\n", SZ_ERROR_MEM);
@@ -372,8 +403,21 @@ retry:
 		return 0;
 	}
 
-	/* Make sure multiple threads don't race on writing lzma_properties */
+	/* Make sure multiple threads don't race on writing lzma_properties.
+	 * If a low memory retry gave some block a smaller dictionary, keep
+	 * the largest so the decoder allocates enough window for every
+	 * block. */
 	lock_mutex(control, &control->control_lock);
+	if (control->lzma_prop_set) {
+		/* dict size is bytes 1-4 of the properties, little endian */
+		u32 stored_dict = control->lzma_properties[1] | control->lzma_properties[2] << 8 |
+			control->lzma_properties[3] << 16 | (u32)control->lzma_properties[4] << 24;
+		u32 this_dict = lzma_properties[1] | lzma_properties[2] << 8 |
+			lzma_properties[3] << 16 | (u32)lzma_properties[4] << 24;
+
+		if (this_dict > stored_dict)
+			memcpy(control->lzma_properties, lzma_properties, 5);
+	}
 	if (!control->lzma_prop_set) {
 		memcpy(control->lzma_properties, lzma_properties, 5);
 		control->lzma_prop_set = true;

--- a/stream.c
+++ b/stream.c
@@ -65,6 +65,7 @@
 
 #include "util.h"
 #include "lrzip_core.h"
+#include "filters.h"
 
 #define STREAM_BUFSIZE (1024 * 1024 * 10)
 
@@ -295,17 +296,33 @@ static int gzip_compress_buf(rzip_control *control, struct compress_thread *cthr
 	return 0;
 }
 
+/* Map a block ctype back to its filter kind, or LRZ_FILTER_NONE */
+static int ctype_filter_kind(int ctype)
+{
+	if (ctype >= CTYPE_LZMA_BCJ && ctype <= CTYPE_LZMA_DELTA4)
+		return LRZ_FILTER_X86 + ctype - CTYPE_LZMA_BCJ;
+	return LRZ_FILTER_NONE;
+}
+
 static int lzma_compress_buf(rzip_control *control, struct compress_thread *cthread)
 {
 	unsigned char lzma_properties[5]; /* lzma properties, encoded */
 	int lzma_level, lzma_fb, lzma_ret;
 	size_t prop_size = 5; /* return value for lzma_properties */
 	u32 dictsize;
+	int filter;
 	uchar *c_buf;
 	size_t dlen;
 
 	if (!lz4_compresses(control, cthread->s_buf, cthread->s_len))
 		return 0;
+
+	/* Convert in place with the chosen prefilter for this block, if any;
+	 * incompressible or failed blocks are converted back before
+	 * returning so stored bytes are always the original ones. */
+	filter = lrz_stream_filter_pick(control, cthread->s_buf, cthread->s_len);
+	if (filter != LRZ_FILTER_NONE)
+		lrz_filter_convert_mem(cthread->s_buf, cthread->s_len, filter, true);
 
 	/* only 7 levels with lzma, scale them. --ultra instead uses the lzma
 	 * level scale directly with an explicit large dictionary, and 273
@@ -336,7 +353,7 @@ retry:
 	c_buf = malloc(dlen);
 	if (!c_buf) {
 		print_err("Unable to allocate c_buf in lzma_compress_buf\n");
-		return -1;
+		goto restore_filter_fail;
 	}
 
 	/* LZMA SDK 26.02 LzmaCompress: level + threads; props returned in
@@ -390,17 +407,19 @@ retry:
 			/* If lzma cannot allocate any dictionary, fall back to
 			 * bzip2 so the block does not remain uncompressed. */
 			print_verbose("Unable to allocate enough RAM for any sized compression window, falling back to bzip2 compression.\n");
+			if (filter != LRZ_FILTER_NONE)
+				lrz_filter_convert_mem(cthread->s_buf, cthread->s_len, filter, false);
 			return bzip2_compress_buf(control, cthread);
 		} else if (lzma_ret == SZ_ERROR_OUTPUT_EOF)
-			return 0;
-		return -1;
+			goto restore_filter_ok;
+		goto restore_filter_fail;
 	}
 
 	if (unlikely((i64)dlen >= cthread->c_len)) {
 		/* Incompressible, leave as CTYPE_NONE */
 		print_maxverbose("Incompressible block\n");
 		dealloc(c_buf);
-		return 0;
+		goto restore_filter_ok;
 	}
 
 	/* Make sure multiple threads don't race on writing lzma_properties.
@@ -432,8 +451,21 @@ retry:
 	cthread->c_len = dlen;
 	dealloc(cthread->s_buf);
 	cthread->s_buf = c_buf;
-	cthread->c_type = CTYPE_LZMA;
+	cthread->c_type = filter == LRZ_FILTER_NONE ? CTYPE_LZMA :
+		CTYPE_LZMA_BCJ + filter - LRZ_FILTER_X86;
 	return 0;
+
+restore_filter_ok:
+	/* Blocks left uncompressed must hold the original bytes, so undo
+	 * any in place filter conversion. */
+	if (filter != LRZ_FILTER_NONE)
+		lrz_filter_convert_mem(cthread->s_buf, cthread->s_len, filter, false);
+	return 0;
+
+restore_filter_fail:
+	if (filter != LRZ_FILTER_NONE)
+		lrz_filter_convert_mem(cthread->s_buf, cthread->s_len, filter, false);
+	return -1;
 }
 
 static int lzo_compress_buf(rzip_control *control, struct compress_thread *cthread)
@@ -1913,6 +1945,17 @@ retry:
 			case CTYPE_LZMA:
 				ret = lzma_decompress_buf(control, uci);
 				break;
+			case CTYPE_LZMA_BCJ:
+			case CTYPE_LZMA_BCJ_ARM64:
+			case CTYPE_LZMA_DELTA1:
+			case CTYPE_LZMA_DELTA2:
+			case CTYPE_LZMA_DELTA3:
+			case CTYPE_LZMA_DELTA4:
+				ret = lzma_decompress_buf(control, uci);
+				if (!ret)
+					lrz_filter_convert_mem(uci->s_buf, uci->u_len,
+							       ctype_filter_kind(uci->c_type), false);
+				break;
 			case CTYPE_LZO:
 				ret = lzo_decompress_buf(control, uci);
 				break;
@@ -2104,7 +2147,8 @@ fill_another:
 	/* Reject unknown types and CTYPE_NONE length mismatches (uninit leak). */
 	if (unlikely(c_type != CTYPE_NONE && c_type != CTYPE_BZIP2 &&
 		     c_type != CTYPE_LZO && c_type != CTYPE_LZMA &&
-		     c_type != CTYPE_GZIP && c_type != CTYPE_ZPAQ)) {
+		     c_type != CTYPE_GZIP && c_type != CTYPE_ZPAQ &&
+		     !(c_type >= CTYPE_LZMA_BCJ && c_type <= CTYPE_LZMA_DELTA4))) {
 		fatal_return(("Invalid compression type %d in stream block\n", c_type), -1);
 	}
 	if (unlikely(c_type == CTYPE_NONE && c_len != u_len)) {

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -423,6 +423,72 @@ run_roundtrip_tests() {
 	[[ "$PASS_FAIL" -eq 0 ]]
 }
 
+# ----------------------------------------------------------------------------
+# Part 3: --ultra and constrained memory tests
+#
+# Exercise the single block ultra path, the explicit dictionary sizing, and
+# the low ram behaviour: with -m the dictionary must be capped to fit the
+# allowance and compression must still round-trip rather than fail.
+# ----------------------------------------------------------------------------
+run_ultra_tests() {
+	local dictline dictsize plain ultra
+	WORKDIR_U="$(mktemp -d "${TMPDIR:-/tmp}/lrzip-ultra.XXXXXX")"
+	log "=== Part 3: ultra suite (WORKDIR=$WORKDIR_U) ==="
+
+	# Round trips through the single block path, including zpaq, an
+	# explicit thread override, and encryption over ultra.
+	run_one "ultra/file/small/lzma" small "-u -L9" file 0
+	run_one "ultra/file/zeros_large/lzma" zeros_large "-u -L9" file 0
+	run_one "ultra/file/small/zpaq" small "-z -u" file 0
+	run_one "ultra/threads/small/lzma" small "-u -L9 -p 2" file 0
+	run_one "ultra/enc/small/lzma" small "-u -L9" file 1
+	run_one "ultra/stdio/small/lzma" small "-u -L9" stdio 0
+
+	# Ultra must not compress a highly compressible input worse than the
+	# threaded default at the same level.
+	make_input "$WORKDIR_U/ratio.bin" zeros_large
+	"$LRZIP" "${BASE_FLAGS[@]}" -L9 -o "$WORKDIR_U/plain.lrz" "$WORKDIR_U/ratio.bin" >/dev/null 2>&1
+	"$LRZIP" "${BASE_FLAGS[@]}" -L9 -u -o "$WORKDIR_U/ultra.lrz" "$WORKDIR_U/ratio.bin" >/dev/null 2>&1
+	plain=$(stat -c%s "$WORKDIR_U/plain.lrz" 2>/dev/null || echo 0)
+	ultra=$(stat -c%s "$WORKDIR_U/ultra.lrz" 2>/dev/null || echo 0)
+	if [[ "$ultra" -gt 0 && "$ultra" -le "$plain" ]]; then
+		log "PASS  ultra/ratio ($ultra <= $plain)"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  ultra/ratio ($ultra > $plain)"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+
+	# Constrained ram: -m 3 caps detected ram at 300MB, so the level 9
+	# ultra dictionary (256MB unconstrained) must be capped to fit
+	# ramsize/3 with the encoder's 11.5x overhead - under 8MB here -
+	# and compression must succeed and round-trip.
+	# BASE_FLAGS carries -Q which silences -vv, so use explicit flags.
+	# Capture to a file: a grep pipe would close early and SIGPIPE lrzip.
+	"$LRZIP" -f -vv -m 3 -L9 -u -o "$WORKDIR_U/mem.lrz" "$WORKDIR_U/ratio.bin" >"$WORKDIR_U/vv.log" 2>&1
+	dictline=$(grep -m1 "Using lzma dictionary size" "$WORKDIR_U/vv.log")
+	dictsize=$(echo "$dictline" | grep -oE '[0-9]+' | head -1)
+	if [[ -n "$dictsize" && "$dictsize" -le $((8 * 1024 * 1024)) ]]; then
+		log "PASS  ultra/lowram-dictcap (dict $dictsize <= 8MB with -m 3)"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  ultra/lowram-dictcap (dict '$dictsize' with -m 3)"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+	"$LRZIP" "${BASE_FLAGS[@]}" -m 3 -d -o "$WORKDIR_U/mem.bin" "$WORKDIR_U/mem.lrz" >/dev/null 2>&1
+	if cmp -s "$WORKDIR_U/ratio.bin" "$WORKDIR_U/mem.bin"; then
+		log "PASS  ultra/lowram-roundtrip"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  ultra/lowram-roundtrip"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+
+	rm -rf "$WORKDIR_U"
+	log "ultra: done"
+	[[ "$PASS_FAIL" -eq 0 ]]
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -437,6 +503,9 @@ fi
 
 if [[ "${SKIP_ROUNDTRIP:-0}" != 1 ]]; then
 	if ! run_roundtrip_tests; then
+		STATUS=1
+	fi
+	if ! run_ultra_tests; then
 		STATUS=1
 	fi
 else

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -4,6 +4,8 @@
 #
 # Part 1: Classic gold-file CLI tests (compat `lrz` behaviour).
 # Part 2: Round-trip matrix (content shapes, backends, STDIO, encryption).
+# Part 3: --ultra single block mode and constrained memory behaviour.
+# Part 4: --filter prefilter round-trips and block type recording.
 #
 # Copyright (C) 2016 Ole Tange and Free Software Foundation, Inc.
 # Copyright (C) 2026 Con Kolivas
@@ -489,6 +491,113 @@ run_ultra_tests() {
 	[[ "$PASS_FAIL" -eq 0 ]]
 }
 
+# ----------------------------------------------------------------------------
+# Part 4: --filter prefilter tests
+#
+# Exercise forced and auto per-block prefilters: every filter kind must
+# round-trip on compressible, incompressible and zero data (incompressible
+# blocks take the stored path, which must restore the original bytes in
+# place), the chosen filter must be recorded in the block type byte and
+# reported by -i, auto trial selection must round-trip, archives written
+# without --filter must carry only classic block types, and -u must imply
+# the automatic prefilters unless --filter is given explicitly.
+# ----------------------------------------------------------------------------
+run_filter_tests() {
+	local ftype
+	WORKDIR_F="$(mktemp -d "${TMPDIR:-/tmp}/lrzip-filter.XXXXXX")"
+	log "=== Part 4: filter suite (WORKDIR=$WORKDIR_F) ==="
+
+	# Forced filters: the conversion itself must round-trip on data it
+	# suits and data it does not.
+	for ftype in x86 arm64 delta1 delta2 delta3 delta4; do
+		run_one "filter/$ftype/small" small "--filter=$ftype" file 0
+		run_one "filter/$ftype/incom_small" incom_small "--filter=$ftype" file 0
+	done
+	run_one "filter/x86/incom_large" incom_large "--filter=x86" file 0
+	run_one "filter/delta2/zeros_large" zeros_large "--filter=delta2" file 0
+	# -T forces the lzma attempt on incompressible data, so the converted
+	# block comes back bigger and must be restored before being stored raw.
+	run_one "filter/x86/incom_large_stored" incom_large "--filter=x86 -T" file 0
+
+	# Auto trial selection, encryption and stdio over filters.
+	run_one "filter/auto/incom_large" incom_large "--filter" file 0
+	run_one "filter/auto/zeros_large" zeros_large "--filter" file 0
+	run_one "filter/enc/small" small "--filter=delta1" file 1
+	run_one "filter/stdio/small" small "--filter=x86" stdio 0
+
+	# The forced filter must be recorded in the block type and reported
+	# by -i, and the archive must still round-trip.
+	seq 1 300000 > "$WORKDIR_F/seq.txt"
+	"$LRZIP" "${BASE_FLAGS[@]}" --filter=delta2 -o "$WORKDIR_F/seq.lrz" "$WORKDIR_F/seq.txt" >/dev/null 2>&1
+	if "$LRZIP" -i -vv "$WORKDIR_F/seq.lrz" 2>/dev/null | grep -q 'lzma+delta2'; then
+		log "PASS  filter/info-blocktype"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  filter/info-blocktype"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+	"$LRZIP" "${BASE_FLAGS[@]}" -d -o "$WORKDIR_F/seq.out" "$WORKDIR_F/seq.lrz" >/dev/null 2>&1
+	if cmp -s "$WORKDIR_F/seq.txt" "$WORKDIR_F/seq.out"; then
+		log "PASS  filter/info-roundtrip"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  filter/info-roundtrip"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+
+	# Without --filter only classic block types may be written.
+	"$LRZIP" "${BASE_FLAGS[@]}" -o "$WORKDIR_F/seq0.lrz" "$WORKDIR_F/seq.txt" >/dev/null 2>&1
+	if "$LRZIP" -i -vv "$WORKDIR_F/seq0.lrz" 2>/dev/null | grep -q 'lzma+'; then
+		log "FAIL  filter/off-classic-blocktypes"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	else
+		log "PASS  filter/off-classic-blocktypes"
+		PASS_OK=$((PASS_OK + 1))
+	fi
+
+	# --filter is only wired into the lzma back end and must be refused
+	# elsewhere.
+	if "$LRZIP" "${BASE_FLAGS[@]}" -b --filter=x86 -o "$WORKDIR_F/no.lrz" "$WORKDIR_F/seq.txt" >/dev/null 2>&1; then
+		log "FAIL  filter/non-lzma-refused"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	else
+		log "PASS  filter/non-lzma-refused"
+		PASS_OK=$((PASS_OK + 1))
+	fi
+
+	# -u implies the automatic prefilters but must respect an explicit
+	# --filter choice: forcing still works and none restores classic
+	# block types under -u.
+	"$LRZIP" "${BASE_FLAGS[@]}" -u --filter=delta2 -o "$WORKDIR_F/useq.lrz" "$WORKDIR_F/seq.txt" >/dev/null 2>&1
+	if "$LRZIP" -i -vv "$WORKDIR_F/useq.lrz" 2>/dev/null | grep -q 'lzma+delta2'; then
+		log "PASS  filter/ultra-forced"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  filter/ultra-forced"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+	"$LRZIP" "${BASE_FLAGS[@]}" -u --filter=none -o "$WORKDIR_F/useq0.lrz" "$WORKDIR_F/seq.txt" >/dev/null 2>&1
+	if "$LRZIP" -i -vv "$WORKDIR_F/useq0.lrz" 2>/dev/null | grep -q 'lzma+'; then
+		log "FAIL  filter/ultra-none-classic"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	else
+		log "PASS  filter/ultra-none-classic"
+		PASS_OK=$((PASS_OK + 1))
+	fi
+	"$LRZIP" "${BASE_FLAGS[@]}" -d -o "$WORKDIR_F/useq.out" "$WORKDIR_F/useq.lrz" >/dev/null 2>&1
+	if cmp -s "$WORKDIR_F/seq.txt" "$WORKDIR_F/useq.out"; then
+		log "PASS  filter/ultra-roundtrip"
+		PASS_OK=$((PASS_OK + 1))
+	else
+		log "FAIL  filter/ultra-roundtrip"
+		PASS_FAIL=$((PASS_FAIL + 1))
+	fi
+
+	rm -rf "$WORKDIR_F"
+	log "filter: done"
+	[[ "$PASS_FAIL" -eq 0 ]]
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -506,6 +615,9 @@ if [[ "${SKIP_ROUNDTRIP:-0}" != 1 ]]; then
 		STATUS=1
 	fi
 	if ! run_ultra_tests; then
+		STATUS=1
+	fi
+	if ! run_filter_tests; then
 		STATUS=1
 	fi
 else

--- a/util.c
+++ b/util.c
@@ -117,7 +117,37 @@ void setup_overhead(rzip_control *control)
 {
 	/* Work out the compression overhead per compression thread for the
 	 * compression back-ends that need a lot of ram */
-	if (LZMA_COMPRESS) {
+	if (LZMA_COMPRESS && ULTRA) {
+		int level = control->compression_level;
+
+		if (!level)
+			level = 1;
+		else if (level > 9)
+			level = 9;
+		/* Dictionary sizes per direct level, larger than the SDK
+		 * defaults: single block ultra hands the encoder whole
+		 * streams that are typically hundreds of MB, so a larger
+		 * window pays off in ratio. open_stream_out reduces threads
+		 * if the overhead does not fit in usable ram. */
+		i64 dictsize = (level <= 4 ? (1 << (level * 2 + 16)) :
+				(level <= 6 ? (1 << (level + 20)) :
+				(level == 7 ? (1 << 26) :
+				(level == 8 ? (1 << 27) : ((i64)1 << 28)))));
+
+		/* The encoder needs ~11.5 times the dictionary per thread; cap
+		 * the dictionary so it fits the third of ram we will allow
+		 * ourselves with room for the block buffers. */
+		i64 dictcap = 1 << 20;
+		while (dictcap * 13 <= control->ramsize / 3 && dictcap < ((i64)1 << 28))
+			dictcap <<= 1;
+		if (dictsize > dictcap)
+			dictsize = dictcap;
+
+		control->lzma_dictsize = dictsize;
+		print_maxverbose("Using lzma dictionary size %"PRId64" for single block ultra\n",
+				 dictsize);
+		control->overhead = (dictsize * 23 / 2) + (6 * 1024 * 1024) + 16384;
+	} else if (LZMA_COMPRESS) {
 		int level = control->compression_level * 7 / 9;
 
 		if (!level)


### PR DESCRIPTION
## Summary

Executable code and sampled numeric data compress measurably smaller when run through a reversible transform before lzma sees them: **branch conversion** (x86 or arm64 BCJ) turns relative call/jump targets into absolute ones so repeated calls to the same function become repeated byte sequences, and **byte delta** (distance 1–4) turns slowly changing sampled data such as 16-bit imagery into small values. This PR adds `--filter[=TYPE]`, applying these per lzma block, chosen by trial compression — and **`-u`/`--ultra` now implies `--filter`** for lzma, per the review discussion in #268: maximum compression means the automatic prefilters too.

**Now stacked on #268** (the first commit is #268's `--ultra`; review the second commit for this change) so the `-u` coupling can live here. The converters (`Bra.c`, `Bra86.c`, `Delta.c`) are vendored from the same public-domain LZMA SDK release lrzip already ships.

**Without `--filter` and without `-u`, nothing changes** — verified byte-identical archives against an unmodified build at levels 1, 7 and 9, with `-p1`, and with the bzip2/gzip/lzo/none/zpaq back ends.

## How it works

- `--filter` (or `--filter=auto`, or implied by `-u`): a 2 MB sample from the middle of each lzma block is trial-compressed with fast settings, plain and after each candidate conversion. A filter is applied only when it beats plain by a clear margin (1/64), so text, source and random data stay unfiltered — measured zero effect on wikipedia text in the development tree, and the trials correctly decline on Silesia sao/osdb.
- `--filter=x86|arm64|delta1..delta4` forces one filter on every block; `--filter=none` disables filtering, including under `-u`.
- The choice is recorded per block in six new block-type values (`CTYPE_LZMA_BCJ` .. `CTYPE_LZMA_DELTA4`) and reversed transparently on decompression. Blocks that end up stored uncompressed are converted back in place first, so stored bytes are always the original bytes.
- `lrzip -i -vv` reports the filter per block (`lzma+bcj`, `lzma+delta2`, …).
- arm64 BCJ is included but rarely wins post-rzip: rzip's byte-granular matching shifts the 4-byte instruction phase the converter needs (verified against `xz --arm64`, which gains 4% on the same aarch64 binaries raw). The trial declines automatically rather than regressing; the pre-rzip conversion in #270 is what unlocks arm64.

## Format impact

This commit changes no header: only new values in the existing per-block type byte. Archives written without filtering (or whose trials all decline) are byte-identical to stock output and fully readable by older lrzip versions; only blocks a filter actually fired on need the new version, and an old reader fails cleanly on them ("Invalid compression type 11 in stream block") rather than producing wrong output. (#270, stacked on top, is where the chunk-header prefilter byte is added for the pre-rzip conversion.)

## Results

Measured on this branch against an unmodified build, default level, archives verified byte-for-byte on decompression:

| Corpus | Stock | Filtered | Δ | Auto-chosen |
|---|---|---|---|---|
| silesia `mr` (16-bit MRI imagery, 10 MB) | 2,785,965 | 2,655,258 | **−4.7%** | delta2 |
| silesia `x-ray` (16-bit film scan, 8.5 MB) | 4,478,406 | 4,251,066 | **−5.1%** | delta2 |
| ubuntu-base amd64 rootfs tar (84 MB x86_64 ELF) | 20,060,923 | 19,733,865 | **−1.6%** | x86 BCJ on code blocks |

On the 1 GB `/usr` ELF benchmark corpus in the development tree the block filters were worth ~2% at the default level, rising with code density; imagery-heavy data sits in the 4–5% band. Trial cost is a fast-lzma pass over 2 MB per block — under `-u` it is noise next to ultra itself.

## Tests

`tests/regression.sh` grows a Part 4 filter suite (26 tests): every filter kind round-tripped over compressible, incompressible and zero data, including the stored-block restore path via `-T`; auto selection round-trips; encryption and stdio over filters; `-i` reporting of the recorded block type; classic-only block types without `--filter`; refusal of `--filter` with non-lzma back ends; and the `-u` implication with forced and `none` overrides. Full suite passes (Parts 1–4 on this branch).
