### PR TITLE
Fix macOS build and runtime failures

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,37 @@
+name: macos
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: brew install autoconf automake libtool pkg-config nasm lzo lz4
+    - name: Build
+      run: |
+        export LDFLAGS="-L$(brew --prefix)/lib"
+        export CPPFLAGS="-I$(brew --prefix)/include"
+        export PKG_CONFIG_PATH="$(brew --prefix)/lib/pkgconfig"
+        NOCONFIGURE=1 ./autogen.sh
+        ./configure
+        make
+        ./lrzip -V
+    - name: Roundtrip (file, --ultra)
+      run: |
+        cat main.c util.c stream.c lzma/C/*.c > text.bin
+        ./lrzip -L9 -u -f -o text.lrz text.bin
+        ./lrzip -t text.lrz
+        ./lrzip -d -f -o text.out text.lrz
+        cmp text.bin text.out
+    - name: Roundtrip (stdin)
+      run: |
+        printf 'hello lrzip on macos\n' > stdin.in
+        cat stdin.in | ./lrzip -f -o stdin.lrz
+        ./lrzip -d -f -o stdin.out stdin.lrz
+        cmp stdin.in stdin.out

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install dependencies
       run: brew install autoconf automake libtool pkg-config nasm lzo lz4
     - name: Build

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,15 @@ case "${host_cpu}" in
     ;;
 esac
 
+# libzpaq expects the 'unix' macro on Unix platforms (see libzpaq/libzpaq.h);
+# GCC and Linux clang predefine it, but Darwin clang does not, sending macOS
+# builds into the Windows branch (#include <windows.h>).
+case "${host_os}" in
+  darwin*)
+    CPPFLAGS="${CPPFLAGS} -Dunix"
+    ;;
+esac
+
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX
@@ -146,7 +155,10 @@ if test x"$ASM" = x"yes"; then
 			ASM_OPT="$ASM_OPT -g -f elf" ;;
 		x86_64-*)
 			ASM_OPT="$ASM_OPT -Dx64 -g -f elf64" ;;
-		*) ASM_OPT= ;;
+		*)
+			# nasm may exist but the ASM sources are x86-only
+			ASM=no
+			ASM_OPT= ;;
 	esac
 else
 	ASM_OPT=

--- a/lrzip.c
+++ b/lrzip.c
@@ -491,7 +491,7 @@ bool write_fdout(rzip_control *control, void *buf, i64 len)
 	ssize_t ret;
 
 	while (len > 0) {
-		ret = write(control->fd_out, offset_buf, (size_t)len);
+		ret = write(control->fd_out, offset_buf, (size_t)MIN(len, MAX_RW_COUNT));
 		if (unlikely(ret <= 0))
 			fatal_return(("Failed to write to fd_out in write_fdout\n"), false);
 		len -= ret;
@@ -592,7 +592,7 @@ bool write_fdin(rzip_control *control)
 	ssize_t ret;
 
 	while (len > 0) {
-		ret = write(control->fd_in, offset_buf, (size_t)len);
+		ret = write(control->fd_in, offset_buf, (size_t)MIN(len, MAX_RW_COUNT));
 		if (unlikely(ret <= 0))
 			fatal_return(("Failed to write to fd_in in write_fdin\n"), false);
 		len -= ret;
@@ -1728,6 +1728,10 @@ bool initialise_control(rzip_control *control)
 	control->threads = get_available_cpus();	/* get CPUs for LZMA */
 	control->page_size = PAGE_SIZE;
 	control->nice_val = 19;
+	/* Initialised here rather than in rzip_fd so the decompress and test
+	 * paths get a valid mutex too; zero-filled mutexes happen to work on
+	 * glibc but fail EINVAL on macOS. */
+	init_mutex(control, &control->control_lock);
 
 	/* The first 5 bytes of the salt is the time in seconds.
 	 * The next 2 bytes encode how many times to hash the password.

--- a/lrzip_private.h
+++ b/lrzip_private.h
@@ -141,6 +141,10 @@ void *alloca (size_t);
 #define MAX(a, b) ((a) > (b)? (a): (b))
 #endif
 
+/* Largest count to pass to a single read()/write(). Linux truncates larger
+ * requests but macOS fails them with EINVAL, so all IO loops must chunk. */
+#define MAX_RW_COUNT (1L << 30)
+
 #if !HAVE_STRERROR
 extern char *sys_errlist[];
 #define strerror(i) sys_errlist[i]

--- a/lzma/ASM/x86/Makefile.am
+++ b/lzma/ASM/x86/Makefile.am
@@ -1,7 +1,9 @@
 MAINTAINERCLEANFILES = Makefile.in
 
+if USE_ASM
 noinst_LTLIBRARIES = liblzmaasm.la
 
 liblzmaasm_la_SOURCES = \
 	7zAsm.asm \
 	7zCrcOpt_asm.asm
+endif

--- a/rzip.c
+++ b/rzip.c
@@ -1142,7 +1142,7 @@ static inline void mmap_stdin(rzip_control *control, uchar *buf,
 
 	total = 0;
 	while (len > 0) {
-		ret = read(fileno(control->inFILE), offset_buf, (size_t)len);
+		ret = read(fileno(control->inFILE), offset_buf, (size_t)MIN(len, MAX_RW_COUNT));
 		if (unlikely(ret < 0))
 			failure("Failed to read in mmap_stdin\n");
 		total += ret;
@@ -1328,7 +1328,6 @@ void rzip_fd(rzip_control *control, int fd_in, int fd_out)
 	struct stat s, s2;
 	i64 free_space;
 
-	init_mutex(control, &control->control_lock);
 	if (!NO_MD5)
 		md5_init_ctx(&control->ctx);
 

--- a/stream.c
+++ b/stream.c
@@ -815,7 +815,7 @@ ssize_t read_all(rzip_control *control, int fd, void *buf, i64 len)
 read_fd:
 	total = 0;
 	while (len > 0) {
-		ret = read(fd, offset_buf, (size_t)len);
+		ret = read(fd, offset_buf, (size_t)MIN(len, MAX_RW_COUNT));
 		if (unlikely(ret <= 0))
 			return ret;
 		len -= ret;


### PR DESCRIPTION
lrzip did not build or run on macOS. This fixes it with a ~27-line source change across `configure.ac`, the lzma ASM makefile, and the read/write paths, plus a small macOS CI job. Behaviour on Linux is unchanged.

Tested on Apple Silicon (macos-latest) and Linux; both build and round-trip cleanly, including `--ultra` and stdin.

## Four pre-existing issues, all invisible on Linux

1. **Empty ASM archive rejected by BSD `ar`.** `lzma/ASM/x86` builds `liblzmaasm.la` even when configure selects no ASM sources for the host, producing a zero-member archive. GNU `ar` tolerates it; BSD `ar` (macOS) rejects it with *"no archive members specified"*. Guarded behind the existing `USE_ASM` conditional, and `ASM=no` is forced on non-x86 hosts where the x86-only sources can't apply even if `nasm` is installed.

2. **libzpaq took the Windows path on macOS.** libzpaq selects platform code on the bare `unix` macro. GCC and Linux clang predefine it; Darwin clang does not, so the build fell into the Windows branch and failed on `#include <windows.h>`. Now defines `-Dunix` for darwin hosts, matching libzpaq's own documented convention.

3. **Uninitialised mutex on decompress/test.** `control->control_lock` was only initialised in the compress path (`rzip_fd`), so `-d`/`-t` operated on a zero-filled mutex. glibc happens to accept that; macOS rejects it with `EINVAL` and every decompress aborted at the end of the first chunk. Moved the init to `initialise_control` so all modes get a valid mutex.

4. **Oversized `read`/`write` syscalls.** The IO loops passed the full remaining length to a single syscall. Linux silently caps oversized requests; macOS fails them with `EINVAL`, which broke all stdin compression once the RAM heuristic sized a chunk past the cap. Each syscall is now chunked at 1 GB (`MAX_RW_COUNT`); the surrounding loops already handle partial transfers.

## CI

Adds a single `macos-latest` job that builds (with `nasm` present, so the `ASM=no` host handling is exercised) and verifies a file `--ultra` round-trip and a stdin round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tyCs6HqrpSPbX4CAT6v7Z