### PR TITLE
Use `(i64)LRZIP_MAX_TOKEN_LEN` for <= 0.4x versions

### DIFF
--- a/runzip.c
+++ b/runzip.c
@@ -196,7 +196,7 @@ static uchar *runzip_get_buf(rzip_control *control, i64 len)
 {
 	uchar *nbuf;
 
-	if (unlikely(!lrzip_size_ok(len, LRZIP_MAX_TOKEN_LEN)))
+	if (unlikely(!lrzip_size_ok(len, lrzip_max_token_len(control))))
 		return NULL;
 	if (likely(len <= control->runzip_buf_len))
 		return control->runzip_buf;
@@ -323,7 +323,7 @@ static i64 unzip_literal(rzip_control *control, void *ss, i64 len,
 	if (!len)
 		return 0;
 
-	if (unlikely(len > LRZIP_MAX_TOKEN_LEN))
+	if (unlikely(len > lrzip_max_token_len(control)))
 		failure_return(("Literal length %"PRId64" exceeds format max\n", len), -1);
 
 	buf = runzip_get_buf(control, len);
@@ -381,7 +381,7 @@ static i64 unzip_match(rzip_control *control, void *ss, struct runzip_s0 *s0,
 	if (unlikely(len < 0))
 		failure_return(("len %"PRId64" is negative in unzip_match!\n",len), -1);
 
-	if (unlikely(len > LRZIP_MAX_TOKEN_LEN))
+	if (unlikely(len > lrzip_max_token_len(control)))
 		failure_return(("Match length %"PRId64" exceeds format max\n", len), -1);
 
 	/* Tracked write position — avoids lseek(SEEK_CUR) every match. */

--- a/util.h
+++ b/util.h
@@ -116,8 +116,13 @@ static inline ssize_t write_maxrw(int fd, void *buf, i64 len)
 	return write(fd, buf, (size_t)MIN(len, MAX_RW_COUNT));
 }
 
-/* rzip match/literal token lengths are always emitted ≤ 0xFFFF. */
+/* rzip match/literal token lengths are always emitted ≤ 0xFFFF.
+ * Format v0.4 stored 8-byte lengths and could emit longer tokens. */
 #define LRZIP_MAX_TOKEN_LEN	0xFFFF
+#define LRZIP_MAX_TOKEN_LEN_V4	((i64)1 << 32)
+#define lrzip_max_token_len(control) \
+	(((control)->major_version == 0 && (control)->minor_version <= 4) ? \
+	LRZIP_MAX_TOKEN_LEN_V4 : (i64)LRZIP_MAX_TOKEN_LEN)
 bool read_config(rzip_control *control);
 void lrz_stretch(rzip_control *control);
 void lrz_stretch2(rzip_control *control);


### PR DESCRIPTION
Fixes #273, only the part for opening an old archive.

Please see #273 for more details.

I believe that the best fix would be reading in chunks so there is no risk for memory. I can take a stab if you want. 